### PR TITLE
Fixed an issue causing Actions.AIGroupsFormationSet(..) to return bytecode error.

### DIFF
--- a/src/scripting/KM_Scripting.pas
+++ b/src/scripting/KM_Scripting.pas
@@ -739,7 +739,7 @@ begin
       RegisterMethod(@TKMScriptActions.AIDefencePositionRemoveAll, 'AIDEFENCEPOSITIONREMOVEALL');
       RegisterMethod(@TKMScriptActions.AIDefendAllies,             'AIDEFENDALLIES');
       RegisterMethod(@TKMScriptActions.AIEquipRate,                'AIEQUIPRATE');
-      RegisterMethod(@TKMScriptActions.AIGroupsFormationSet,       'AIGROUPSFORMATIONSET)');
+      RegisterMethod(@TKMScriptActions.AIGroupsFormationSet,       'AIGROUPSFORMATIONSET');
       RegisterMethod(@TKMScriptActions.AIRecruitDelay,             'AIRECRUITDELAY');
       RegisterMethod(@TKMScriptActions.AIRecruitLimit,             'AIRECRUITLIMIT');
       RegisterMethod(@TKMScriptActions.AISerfsPerHouse,            'AISERFSPERHOUSE');


### PR DESCRIPTION
The issue was a bracket that shouldn't be there.
