### PR TITLE
Ability to change train queue priorities in school

### DIFF
--- a/src/KM_Defaults.pas
+++ b/src/KM_Defaults.pas
@@ -147,6 +147,9 @@ const
   MAX_WARES_ORDER     = 999;  //Number of max allowed items to be ordered in production houses (Weapon/Armor/etc)
 
 const
+  MAX_WOODCUTTER_CUT_PNT_DISTANCE = 8; //Max distance for woodcutter new cutting point from his house
+
+const
   MAX_HANDS            = 12; //Maximum players (human or AI) per map
   MAX_LOBBY_PLAYERS    = 8;  //Maximum number of players (not spectators) allowed in the lobby. Map can have additional AI locations up to MAX_HANDS (for co-op).
   MAX_LOBBY_SPECTATORS = 2;  //Slots available in lobby. Additional slots can be used by spectators

--- a/src/KM_GameInputProcess.pas
+++ b/src/KM_GameInputProcess.pas
@@ -62,12 +62,12 @@ type
     gic_HouseWoodcutterMode,      //Switch the woodcutter mode
     gic_HouseStoreAcceptFlag,     //Control wares delivery to store
     gic_HouseSchoolTrain,         //Place an order to train citizen
-    gic_HouseSchoolTrainChPriority, //Change school train order (priority)
+    gic_HouseSchoolTrainChOrder,  //Change school training order
     gic_HouseBarracksAcceptFlag,  //Control wares delivery to barracks
     gic_HouseBarracksEquip,       //Place an order to train warrior
     gic_HouseBarracksRally,       //Set the rally point for the barracks
-    gic_HouseRemoveTrain,         //Remove unit being trained from School
-    gic_HouseWoodcuttersCutting,       //Set the cutting point for the Woodcutters
+    gic_HouseRemoveTrain,         //Remove unit being trained from School    
+    gic_HouseWoodcuttersCutting,  //Set the cutting point for the Woodcutters
 
     //IV.     Delivery ratios changes (and other game-global settings)
     gic_RatioChange,
@@ -155,7 +155,6 @@ type
     procedure CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aItem: TWareType); overload;
     procedure CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aWoodcutterMode: TWoodcutterMode); overload;
     procedure CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aUnitType: TUnitType; aCount:byte); overload;
-    procedure CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aUnitType: TUnitType; aOldPriority, aNewPriority: Byte); overload;
     procedure CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aItem: Integer); overload;
     procedure CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aLoc: TKMPoint); overload;
 
@@ -310,10 +309,10 @@ begin
       if (TgtUnit = nil) or TgtUnit.IsDeadOrDying then //Unit has died before command could be executed
         Exit;
     end;
-    if CommandType in [gic_HouseRepairToggle, gic_HouseDeliveryToggle,
-      gic_HouseOrderProduct, gic_HouseMarketFrom, gic_HouseMarketTo, gic_HouseBarracksRally, gic_HouseWoodcuttersCutting,
+    if CommandType in [gic_HouseRepairToggle, gic_HouseDeliveryToggle, gic_HouseWoodcuttersCutting,
+      gic_HouseOrderProduct, gic_HouseMarketFrom, gic_HouseMarketTo, gic_HouseBarracksRally,
       gic_HouseStoreAcceptFlag, gic_HouseBarracksAcceptFlag, gic_HouseBarracksEquip,
-      gic_HouseSchoolTrain, gic_HouseSchoolTrainChPriority, gic_HouseRemoveTrain, gic_HouseWoodcutterMode] then
+      gic_HouseSchoolTrain, gic_HouseSchoolTrainChOrder, gic_HouseRemoveTrain, gic_HouseWoodcutterMode] then
     begin
       SrcHouse := gHands.GetHouseByUID(Params[1]);
       if (SrcHouse = nil) or SrcHouse.IsDestroyed //House has been destroyed before command could be executed
@@ -368,7 +367,7 @@ begin
       gic_HouseBarracksEquip:     TKMHouseBarracks(SrcHouse).Equip(TUnitType(Params[2]), Params[3]);
       gic_HouseBarracksRally:     TKMHouseBarracks(SrcHouse).RallyPoint := KMPoint(Params[2], Params[3]);
       gic_HouseSchoolTrain:       TKMHouseSchool(SrcHouse).AddUnitToQueue(TUnitType(Params[2]), Params[3]);
-      gic_HouseSchoolTrainChPriority: TKMHouseSchool(SrcHouse).ChangeUnitTrainPriority(TUnitType(Params[2]), Params[3], Params[4]);
+      gic_HouseSchoolTrainChOrder:TKMHouseSchool(SrcHouse).ChangeUnitTrainOrder(Params[2], Params[3]);
       gic_HouseRemoveTrain:       TKMHouseSchool(SrcHouse).RemUnitFromQueue(Params[2]);
       gic_HouseWoodcuttersCutting: TKMHouseWoodcutters(SrcHouse).CuttingPoint := KMPoint(Params[2], Params[3]);
 
@@ -512,7 +511,7 @@ end;
 
 procedure TGameInputProcess.CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aItem, aAmountChange: Integer);
 begin
-  Assert(aCommandType = gic_HouseOrderProduct);
+  Assert(aCommandType in [gic_HouseOrderProduct, gic_HouseSchoolTrainChOrder]);
   TakeCommand(MakeCommand(aCommandType, [aHouse.UID, aItem, aAmountChange]));
 end;
 
@@ -535,13 +534,6 @@ procedure TGameInputProcess.CmdHouse(aCommandType: TGameInputCommandType; aHouse
 begin
   Assert(aCommandType in [gic_HouseSchoolTrain, gic_HouseBarracksEquip]);
   TakeCommand(MakeCommand(aCommandType, [aHouse.UID, byte(aUnitType), aCount]));
-end;
-
-//UnitType parameter ignored...
-procedure TGameInputProcess.CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aUnitType: TUnitType; aOldPriority, aNewPriority: Byte);
-begin
-  Assert(aCommandType = gic_HouseSchoolTrainChPriority);
-  TakeCommand(MakeCommand(aCommandType, [aHouse.UID, byte(aUnitType), aOldPriority, aNewPriority]));
 end;
 
 
@@ -723,3 +715,4 @@ end;
 
 
 end.
+

--- a/src/KM_GameInputProcess.pas
+++ b/src/KM_GameInputProcess.pas
@@ -66,6 +66,7 @@ type
     gic_HouseBarracksEquip,       //Place an order to train warrior
     gic_HouseBarracksRally,       //Set the rally point for the barracks
     gic_HouseRemoveTrain,         //Remove unit being trained from School
+    gic_HouseWoodcuttersCutting,       //Set the cutting point for the Woodcutters
 
     //IV.     Delivery ratios changes (and other game-global settings)
     gic_RatioChange,
@@ -308,7 +309,7 @@ begin
         Exit;
     end;
     if CommandType in [gic_HouseRepairToggle, gic_HouseDeliveryToggle,
-      gic_HouseOrderProduct, gic_HouseMarketFrom, gic_HouseMarketTo, gic_HouseBarracksRally,
+      gic_HouseOrderProduct, gic_HouseMarketFrom, gic_HouseMarketTo, gic_HouseBarracksRally, gic_HouseWoodcuttersCutting,
       gic_HouseStoreAcceptFlag, gic_HouseBarracksAcceptFlag, gic_HouseBarracksEquip,
       gic_HouseSchoolTrain, gic_HouseRemoveTrain, gic_HouseWoodcutterMode] then
     begin
@@ -366,6 +367,7 @@ begin
       gic_HouseBarracksRally:     TKMHouseBarracks(SrcHouse).RallyPoint := KMPoint(Params[2], Params[3]);
       gic_HouseSchoolTrain:       TKMHouseSchool(SrcHouse).AddUnitToQueue(TUnitType(Params[2]), Params[3]);
       gic_HouseRemoveTrain:       TKMHouseSchool(SrcHouse).RemUnitFromQueue(Params[2]);
+      gic_HouseWoodcuttersCutting: TKMHouseWoodcutters(SrcHouse).CuttingPoint := KMPoint(Params[2], Params[3]);
 
       gic_RatioChange:            begin
                                     P.Stats.Ratio[TWareType(Params[1]), THouseType(Params[2])] := Params[3];
@@ -543,8 +545,8 @@ end;
 
 procedure TGameInputProcess.CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aLoc: TKMPoint);
 begin
-  Assert(aCommandType = gic_HouseBarracksRally);
-  Assert(aHouse is TKMHouseBarracks);
+  Assert((aCommandType = gic_HouseBarracksRally) or (aCommandType = gic_HouseWoodcuttersCutting));
+  Assert((aHouse is TKMHouseBarracks) or (aHouse is TKMHouseWoodcutters));
   TakeCommand(MakeCommand(aCommandType, [aHouse.UID, aLoc.X, aLoc.Y]));
 end;
 

--- a/src/KM_GameInputProcess.pas
+++ b/src/KM_GameInputProcess.pas
@@ -62,6 +62,7 @@ type
     gic_HouseWoodcutterMode,      //Switch the woodcutter mode
     gic_HouseStoreAcceptFlag,     //Control wares delivery to store
     gic_HouseSchoolTrain,         //Place an order to train citizen
+    gic_HouseSchoolTrainChPriority, //Change school train order (priority)
     gic_HouseBarracksAcceptFlag,  //Control wares delivery to barracks
     gic_HouseBarracksEquip,       //Place an order to train warrior
     gic_HouseBarracksRally,       //Set the rally point for the barracks
@@ -154,6 +155,7 @@ type
     procedure CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aItem: TWareType); overload;
     procedure CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aWoodcutterMode: TWoodcutterMode); overload;
     procedure CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aUnitType: TUnitType; aCount:byte); overload;
+    procedure CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aUnitType: TUnitType; aOldPriority, aNewPriority: Byte); overload;
     procedure CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aItem: Integer); overload;
     procedure CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aLoc: TKMPoint); overload;
 
@@ -311,7 +313,7 @@ begin
     if CommandType in [gic_HouseRepairToggle, gic_HouseDeliveryToggle,
       gic_HouseOrderProduct, gic_HouseMarketFrom, gic_HouseMarketTo, gic_HouseBarracksRally, gic_HouseWoodcuttersCutting,
       gic_HouseStoreAcceptFlag, gic_HouseBarracksAcceptFlag, gic_HouseBarracksEquip,
-      gic_HouseSchoolTrain, gic_HouseRemoveTrain, gic_HouseWoodcutterMode] then
+      gic_HouseSchoolTrain, gic_HouseSchoolTrainChPriority, gic_HouseRemoveTrain, gic_HouseWoodcutterMode] then
     begin
       SrcHouse := gHands.GetHouseByUID(Params[1]);
       if (SrcHouse = nil) or SrcHouse.IsDestroyed //House has been destroyed before command could be executed
@@ -366,6 +368,7 @@ begin
       gic_HouseBarracksEquip:     TKMHouseBarracks(SrcHouse).Equip(TUnitType(Params[2]), Params[3]);
       gic_HouseBarracksRally:     TKMHouseBarracks(SrcHouse).RallyPoint := KMPoint(Params[2], Params[3]);
       gic_HouseSchoolTrain:       TKMHouseSchool(SrcHouse).AddUnitToQueue(TUnitType(Params[2]), Params[3]);
+      gic_HouseSchoolTrainChPriority: TKMHouseSchool(SrcHouse).ChangeUnitTrainPriority(TUnitType(Params[2]), Params[3], Params[4]);
       gic_HouseRemoveTrain:       TKMHouseSchool(SrcHouse).RemUnitFromQueue(Params[2]);
       gic_HouseWoodcuttersCutting: TKMHouseWoodcutters(SrcHouse).CuttingPoint := KMPoint(Params[2], Params[3]);
 
@@ -532,6 +535,13 @@ procedure TGameInputProcess.CmdHouse(aCommandType: TGameInputCommandType; aHouse
 begin
   Assert(aCommandType in [gic_HouseSchoolTrain, gic_HouseBarracksEquip]);
   TakeCommand(MakeCommand(aCommandType, [aHouse.UID, byte(aUnitType), aCount]));
+end;
+
+//UnitType parameter ignored...
+procedure TGameInputProcess.CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aUnitType: TUnitType; aOldPriority, aNewPriority: Byte);
+begin
+  Assert(aCommandType = gic_HouseSchoolTrainChPriority);
+  TakeCommand(MakeCommand(aCommandType, [aHouse.UID, byte(aUnitType), aOldPriority, aNewPriority]));
 end;
 
 

--- a/src/KM_Points.pas
+++ b/src/KM_Points.pas
@@ -37,6 +37,7 @@ type
   function KMPointX1Y1(P:TKMPoint): TKMPoint;
   function KMPointBelow(P: TKMPoint): TKMPoint;
   function KMPointAbove(P: TKMPoint): TKMPoint;
+  function KMNormVector(const P: TKMPoint; R: Integer): TKMPoint;
 
   function KMPointRound(const P: TKMPointF): TKMPoint;
   function KMSamePoint(P1,P2: TKMPoint): Boolean; overload;
@@ -168,6 +169,11 @@ begin
   Result.Y := P.Y - 1;
 end;
 
+function KMNormVector(const P: TKMPoint; R: Integer): TKMPoint;
+begin
+  Result.X := Round(R*P.X / sqrt(sqr(P.X) + sqr(P.Y)));
+  Result.Y := Round(R*P.Y / sqrt(sqr(P.X) + sqr(P.Y)));
+end;
 
 function KMPointRound(const P: TKMPointF): TKMPoint;
 begin

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -634,11 +634,17 @@ begin
       gSoundPlayer.PlayWarrior(Group.UnitType, sp_Move);
     end;
   end;
-  if (gMySpectator.Selected is TKMHouseBarracks) and not fPlacingBeacon
+  if ((gMySpectator.Selected is TKMHouseBarracks) or (gMySpectator.Selected is TKMHouseWoodcutters)) and not fPlacingBeacon
   and (fUIMode in [umSP, umMP]) and not HasLostMPGame then
   begin
     if gTerrain.Route_CanBeMade(KMPointBelow(TKMHouse(gMySpectator.Selected).GetEntrance), Loc, tpWalk, 0) then
-      gGame.GameInputProcess.CmdHouse(gic_HouseBarracksRally, TKMHouse(gMySpectator.Selected), Loc)
+    begin
+      if gMySpectator.Selected is TKMHouseBarracks then
+        gGame.GameInputProcess.CmdHouse(gic_HouseBarracksRally, TKMHouse(gMySpectator.Selected), Loc)
+      else
+        if gMySpectator.Selected is TKMHouseWoodcutters then
+        gGame.GameInputProcess.CmdHouse(gic_HouseWoodcuttersCutting, TKMHouse(gMySpectator.Selected), Loc);
+    end
     else
       gSoundPlayer.Play(sfx_CantPlace, Loc, False, 4);
   end;
@@ -3166,11 +3172,17 @@ begin
           Exit; // Don't order troops too
         end;
 
-        if (gMySpectator.Selected is TKMHouseBarracks) and not fPlacingBeacon
+        if ((gMySpectator.Selected is TKMHouseBarracks) or (gMySpectator.Selected is TKMHouseWoodcutters)) and not fPlacingBeacon
         and (fUIMode in [umSP, umMP]) and not HasLostMPGame then
         begin
           if gTerrain.Route_CanBeMade(KMPointBelow(TKMHouse(gMySpectator.Selected).GetEntrance), P, tpWalk, 0) then
-            gGame.GameInputProcess.CmdHouse(gic_HouseBarracksRally, TKMHouse(gMySpectator.Selected), P)
+          begin
+            if gMySpectator.Selected is TKMHouseBarracks then
+              gGame.GameInputProcess.CmdHouse(gic_HouseBarracksRally, TKMHouse(gMySpectator.Selected), P)
+            else
+              if gMySpectator.Selected is TKMHouseWoodcutters then
+                gGame.GameInputProcess.CmdHouse(gic_HouseWoodcuttersCutting, TKMHouse(gMySpectator.Selected), P);
+          end
           else
             gSoundPlayer.Play(sfx_CantPlace, P, False, 4);
           Exit;

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -643,7 +643,7 @@ begin
         gGame.GameInputProcess.CmdHouse(gic_HouseBarracksRally, TKMHouse(gMySpectator.Selected), Loc)
       else
         if gMySpectator.Selected is TKMHouseWoodcutters then
-        gGame.GameInputProcess.CmdHouse(gic_HouseWoodcuttersCutting, TKMHouse(gMySpectator.Selected), Loc);
+          gGame.GameInputProcess.CmdHouse(gic_HouseWoodcuttersCutting, TKMHouse(gMySpectator.Selected), Loc);
     end
     else
       gSoundPlayer.Play(sfx_CantPlace, Loc, False, 4);
@@ -3486,3 +3486,4 @@ end;
 
 
 end.
+

--- a/src/gui/pages_game/KM_GUIGameHouse.pas
+++ b/src/gui/pages_game/KM_GUIGameHouse.pas
@@ -840,9 +840,9 @@ begin
       QueueCount := School.QueueCount;
       gGame.GameInputProcess.CmdHouse(gic_HouseSchoolTrain, School, School_Order[fLastSchoolUnit], 1);
       if (ssShift in Shift) then
-        gGame.GameInputProcess.CmdHouse(gic_HouseSchoolTrainChPriority, School, ut_None, QueueCount, 0)
+        gGame.GameInputProcess.CmdHouse(gic_HouseSchoolTrainChOrder, School, QueueCount, 0)
       else if ssCtrl in Shift then
-        gGame.GameInputProcess.CmdHouse(gic_HouseSchoolTrainChPriority, School, ut_None, QueueCount, min(QueueCount,1));
+        gGame.GameInputProcess.CmdHouse(gic_HouseSchoolTrainChOrder, School, QueueCount, min(QueueCount,1));
     end;
   end;
 
@@ -904,9 +904,9 @@ begin
     for I := School.QueueLength - 1 downto id do
       gGame.GameInputProcess.CmdHouse(gic_HouseRemoveTrain, School, I)
   else if (ssShift in Shift) then
-    gGame.GameInputProcess.CmdHouse(gic_HouseSchoolTrainChPriority, School, ut_None, id, 0)
+    gGame.GameInputProcess.CmdHouse(gic_HouseSchoolTrainChOrder, School, id, 0)
   else if ssCtrl in Shift then
-    gGame.GameInputProcess.CmdHouse(gic_HouseSchoolTrainChPriority, School, ut_None, id, min(id,1))
+    gGame.GameInputProcess.CmdHouse(gic_HouseSchoolTrainChOrder, School, id, min(id,1))
   else
     gGame.GameInputProcess.CmdHouse(gic_HouseRemoveTrain, School, id);
 

--- a/src/hands/KM_Hand.pas
+++ b/src/hands/KM_Hand.pas
@@ -4,7 +4,7 @@ interface
 uses
   Classes, KromUtils, SysUtils, Math,
   KM_CommonClasses, KM_Defaults, KM_Points,
-  KM_AIArmyEvaluation, KM_BuildList, KM_Deliveries, KM_FogOfWar, KM_MessageLog,
+  KM_AIArmyEvaluation, KM_BuildList, KM_HandLogistics, KM_FogOfWar, KM_MessageLog,
   KM_HouseCollection, KM_Houses, KM_HouseInn, KM_Terrain, KM_AI, KM_HandStats, KM_HandLocks,
   KM_Units, KM_UnitsCollection, KM_Units_Warrior, KM_UnitGroups, KM_ResHouses;
 
@@ -43,7 +43,7 @@ type
     fAI: TKMHandAI;
     fArmyEval: TKMArmyEvaluation;
     fBuildList: TKMBuildList; //Not the best name for buildingManagement
-    fDeliveries: TKMDeliveries;
+    fDeliveries: TKMHandLogistics;
     fFogOfWar: TKMFogOfWar; //Stores FOW info for current player, which includes
     fHouses: TKMHousesCollection;
     fLocks: TKMHandLocks;
@@ -82,7 +82,7 @@ type
 
     property AI: TKMHandAI read fAI;
     property BuildList: TKMBuildList read fBuildList;
-    property Deliveries: TKMDeliveries read fDeliveries;
+    property Deliveries: TKMHandLogistics read fDeliveries;
     property Houses: TKMHousesCollection read fHouses;
     property Locks: TKMHandLocks read fLocks;
     property Stats: TKMHandStats read fStats;
@@ -255,7 +255,7 @@ begin
   fStats        := TKMHandStats.Create;
   fRoadsList    := TKMPointList.Create;
   fHouses       := TKMHousesCollection.Create;
-  fDeliveries   := TKMDeliveries.Create;
+  fDeliveries   := TKMHandLogistics.Create;
   fBuildList    := TKMBuildList.Create;
   fArmyEval     := TKMArmyEvaluation.Create(aHandIndex);
   fUnitGroups   := TKMUnitGroups.Create;

--- a/src/houses/KM_HouseMarket.pas
+++ b/src/houses/KM_HouseMarket.pas
@@ -48,7 +48,7 @@ type
 
 implementation
 uses
-  KM_Deliveries, KM_HandsCollection, KM_RenderPool, KM_Resource, KM_Sound, KM_ResSound, KM_ScriptingEvents, KM_Hand;
+  KM_HandLogistics, KM_HandsCollection, KM_RenderPool, KM_Resource, KM_Sound, KM_ResSound, KM_ScriptingEvents, KM_Hand;
 
 
 { TKMHouseMarket }

--- a/src/houses/KM_HouseSchool.pas
+++ b/src/houses/KM_HouseSchool.pas
@@ -26,7 +26,7 @@ type
     procedure DemolishHouse(aFrom: TKMHandIndex; IsSilent: Boolean = False); override;
     procedure ResAddToIn(aWare: TWareType; aCount: Word = 1; aFromScript: Boolean = False); override;
     function AddUnitToQueue(aUnit: TUnitType; aCount: Byte): Byte; //Should add unit to queue if there's a place
-    procedure ChangeUnitTrainPriority(aUnitType: TUnitType; aOldPriority, aNewPriority: Byte); //Change unit priority in queue
+    procedure ChangeUnitTrainOrder(aOldPosition, aNewPosition: Integer); //Change unit order in queue
     procedure RemUnitFromQueue(aID: Byte); //Should remove unit from queue and shift rest up
     procedure UnitTrainingComplete(aUnit: Pointer); //This should shift queue filling rest with ut_None
     function GetTrainingProgress: Single;
@@ -131,31 +131,34 @@ begin
 end;
 
 //Change unit priority in training queue
-procedure TKMHouseSchool.ChangeUnitTrainPriority(aUnitType: TUnitType; aOldPriority, aNewPriority: Byte);
+procedure TKMHouseSchool.ChangeUnitTrainOrder(aOldPosition, aNewPosition: Integer);
 var tmpUnit: TUnitType;
   I: Byte;
 begin
-  Assert((aNewPriority >= 0) and (aOldPriority <= 5));
+  Assert((aNewPosition >= 0) and (aOldPosition <= 5));
+
+  if aOldPosition = 0 then Exit;
+
   // Do not cancel current training process, if unit type is the same.
-  if (aNewPriority = 0) and (fQueue[aOldPriority] = fQueue[0]) then
-    aNewPriority := 1;
+  if (aNewPosition = 0) and (fQueue[aOldPosition] = fQueue[0]) then
+    aNewPosition := 1;
 
-  if (fQueue[aOldPriority] = ut_None) or (aOldPriority = aNewPriority) then Exit;
+  if (fQueue[aOldPosition] = ut_None) or (aOldPosition = aNewPosition) then Exit;
 
-  Assert(aNewPriority < aOldPriority);
+  Assert(aNewPosition < aOldPosition);
 
-  tmpUnit := fQueue[aOldPriority];
-  for I := aOldPriority downto max(aNewPriority, 0)+1 do
+  tmpUnit := fQueue[aOldPosition];
+  for I := aOldPosition downto max(aNewPosition, 0)+1 do
   begin
     fQueue[I] := fQueue[I-1];
   end;
 
-  if (aNewPriority = 0) then
+  if (aNewPosition = 0) then
     CancelTrainingUnit;
 
-  fQueue[aNewPriority] := tmpUnit;
+  fQueue[aNewPosition] := tmpUnit;
 
-  if (aNewPriority = 0) then
+  if (aNewPosition = 0) then
     CreateUnit;
 end;
 

--- a/src/houses/KM_Houses.pas
+++ b/src/houses/KM_Houses.pas
@@ -206,10 +206,12 @@ type
     fWoodcutterMode: TWoodcutterMode;
     procedure SetWoodcutterMode(aWoodcutterMode: TWoodcutterMode);
   public
+    CuttingPoint: TKMPoint;
     property WoodcutterMode: TWoodcutterMode read fWoodcutterMode write SetWoodcutterMode;
     constructor Create(aUID: Integer; aHouseType: THouseType; PosX, PosY: Integer; aOwner: TKMHandIndex; aBuildState: THouseBuildState);
     constructor Load(LoadStream: TKMemoryStream); override;
     procedure Save(SaveStream: TKMemoryStream); override;
+    function IsCuttingPointSet: Boolean;
   end;
 
 
@@ -322,7 +324,6 @@ begin
   LoadStream.Read(ResourceDepletedMsgIssued);
   LoadStream.Read(DoorwayUse);
 end;
-
 
 procedure TKMHouse.SyncLoad;
 begin
@@ -458,6 +459,7 @@ begin
   if gMySpectator.Hand.CanAddHousePlan(aPos, HouseType) then
   begin
     fPosition.X := aPos.X - gRes.HouseDat[fHouseType].EntranceOffsetX;
+
     fPosition.Y := aPos.Y;
   end;
   gTerrain.SetHouse(fPosition, fHouseType, hsBuilt, fOwner);
@@ -1603,13 +1605,15 @@ constructor TKMHouseWoodcutters.Create(aUID: Integer; aHouseType: THouseType; Po
 begin
   inherited;
   WoodcutterMode := wcm_ChopAndPlant;
+  CuttingPoint := KMPointBelow(GetEntrance);
 end;
-
 
 constructor TKMHouseWoodcutters.Load(LoadStream: TKMemoryStream);
 begin
   inherited;
   LoadStream.Read(fWoodcutterMode, SizeOf(fWoodcutterMode));
+  CuttingPoint := KMPointBelow(GetEntrance);
+  LoadStream.Read(CuttingPoint);
 end;
 
 
@@ -1617,6 +1621,12 @@ procedure TKMHouseWoodcutters.Save(SaveStream: TKMemoryStream);
 begin
   inherited;
   SaveStream.Write(fWoodcutterMode, SizeOf(fWoodcutterMode));
+  SaveStream.Write(CuttingPoint);
+end;
+
+function TKMHouseWoodcutters.IsCuttingPointSet: Boolean;
+begin
+  Result := not KMSamePoint(CuttingPoint, KMPointBelow(GetEntrance));
 end;
 
 

--- a/src/houses/KM_Houses.pas
+++ b/src/houses/KM_Houses.pas
@@ -204,21 +204,22 @@ type
   TKMHouseWoodcutters = class(TKMHouse)
   private
     fWoodcutterMode: TWoodcutterMode;
+    fCuttingPoint: TKMPoint;
     procedure SetWoodcutterMode(aWoodcutterMode: TWoodcutterMode);
+    procedure SetCuttingPoint(Value: TKMPoint);
   public
-    CuttingPoint: TKMPoint;
     property WoodcutterMode: TWoodcutterMode read fWoodcutterMode write SetWoodcutterMode;
     constructor Create(aUID: Integer; aHouseType: THouseType; PosX, PosY: Integer; aOwner: TKMHandIndex; aBuildState: THouseBuildState);
     constructor Load(LoadStream: TKMemoryStream); override;
     procedure Save(SaveStream: TKMemoryStream); override;
     function IsCuttingPointSet: Boolean;
+    property CuttingPoint: TKMPoint read fCuttingPoint write SetCuttingPoint;
   end;
-
 
 implementation
 uses
   KM_CommonTypes, KM_RenderPool, KM_RenderAux, KM_Units, KM_Units_Warrior, KM_ScriptingEvents,
-  KM_HandsCollection, KM_ResSound, KM_Sound, KM_Game, KM_ResTexts, KM_Deliveries,
+  KM_HandsCollection, KM_ResSound, KM_Sound, KM_Game, KM_ResTexts, KM_HandLogistics,
   KM_Resource, KM_Utils, KM_FogOfWar, KM_AI, KM_Hand;
 
 
@@ -324,6 +325,7 @@ begin
   LoadStream.Read(ResourceDepletedMsgIssued);
   LoadStream.Read(DoorwayUse);
 end;
+
 
 procedure TKMHouse.SyncLoad;
 begin
@@ -459,7 +461,6 @@ begin
   if gMySpectator.Hand.CanAddHousePlan(aPos, HouseType) then
   begin
     fPosition.X := aPos.X - gRes.HouseDat[fHouseType].EntranceOffsetX;
-
     fPosition.Y := aPos.Y;
   end;
   gTerrain.SetHouse(fPosition, fHouseType, hsBuilt, fOwner);
@@ -1608,12 +1609,12 @@ begin
   CuttingPoint := KMPointBelow(GetEntrance);
 end;
 
+
 constructor TKMHouseWoodcutters.Load(LoadStream: TKMemoryStream);
 begin
   inherited;
   LoadStream.Read(fWoodcutterMode, SizeOf(fWoodcutterMode));
-  CuttingPoint := KMPointBelow(GetEntrance);
-  LoadStream.Read(CuttingPoint);
+  LoadStream.Read(fCuttingPoint);
 end;
 
 
@@ -1621,7 +1622,7 @@ procedure TKMHouseWoodcutters.Save(SaveStream: TKMemoryStream);
 begin
   inherited;
   SaveStream.Write(fWoodcutterMode, SizeOf(fWoodcutterMode));
-  SaveStream.Write(CuttingPoint);
+  SaveStream.Write(fCuttingPoint);
 end;
 
 function TKMHouseWoodcutters.IsCuttingPointSet: Boolean;
@@ -1629,6 +1630,19 @@ begin
   Result := not KMSamePoint(CuttingPoint, KMPointBelow(GetEntrance));
 end;
 
+procedure TKMHouseWoodcutters.SetCuttingPoint(Value: TKMPoint);
+var
+  EntrancePoint: TKMPoint;
+begin
+  EntrancePoint := GetEntrance;
+  if KMDistanceSqr(EntrancePoint, Value) > Sqr(MAX_WOODCUTTER_CUT_PNT_DISTANCE) then
+  begin
+    Value := KMNormVector(KMPoint(Value.X - EntrancePoint.X, Value.Y - EntrancePoint.Y), MAX_WOODCUTTER_CUT_PNT_DISTANCE);
+    fCuttingPoint := KMPoint(EntrancePoint.X + Value.X, EntrancePoint.Y + Value.Y);
+  end
+  else
+    fCuttingPoint := Value;
+end;
 
 procedure TKMHouseWoodcutters.SetWoodcutterMode(aWoodcutterMode: TWoodcutterMode);
 begin
@@ -1637,7 +1651,6 @@ begin
   if fWoodcutterMode = wcm_ChopAndPlant then
     ResourceDepletedMsgIssued := False;
 end;
-
 
 { THouseAction }
 constructor THouseAction.Create(aHouse: TKMHouse; aHouseState: THouseState);

--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -368,24 +368,51 @@ end;
 procedure TRenderPool.PaintRallyPoints(aPass: Byte);
 var
   B: TKMHouseBarracks;
+  C: TKMHouseWoodcutters;
   P: TKMPointF;
+  PcPrev, PcNext: TKMPointF;
+  i: Integer;
 begin
   if gGame.IsMapEditor then Exit; // Don't render rally point in map editor
-  if not (gMySpectator.Selected is TKMHouseBarracks) then Exit;
-  B := TKMHouseBarracks(gMySpectator.Selected);
-  P := KMPointF(B.RallyPoint.X-0.5, B.RallyPoint.Y-0.5);
-  if B.IsRallyPointSet then
+  if not (gMySpectator.Selected is TKMHouseBarracks) and not (gMySpectator.Selected is TKMHouseWoodcutters) then
+    Exit;
+
+  if gMySpectator.Selected is TKMHouseBarracks then
   begin
-    case aPass of
-      0: begin
-           AddAlert(P, 249, gHands[B.Owner].FlagColor);
-           gRenderAux.LineOnTerrain(B.GetEntrance.X-0.5, B.GetEntrance.Y-0.5, P.X, P.Y, gHands[B.Owner].FlagColor, $F0F0, False);
-         end;
-      1: if gMySpectator.FogOfWar.CheckRevelation(P) < FOG_OF_WAR_MAX then
-           fRenderPool.RenderSpriteOnTerrain(P, 249, gHands[B.Owner].FlagColor);
+    B := TKMHouseBarracks(gMySpectator.Selected);
+    P := KMPointF(B.RallyPoint.X-0.5, B.RallyPoint.Y-0.5);
+    if B.IsRallyPointSet then
+    begin
+      case aPass of
+        0: begin
+             AddAlert(P, 249, gHands[B.Owner].FlagColor);
+             gRenderAux.LineOnTerrain(B.GetEntrance.X-0.5, B.GetEntrance.Y-0.5, P.X, P.Y, gHands[B.Owner].FlagColor, $F0F0, False);
+           end;
+        1: if gMySpectator.FogOfWar.CheckRevelation(P) < FOG_OF_WAR_MAX then
+             fRenderPool.RenderSpriteOnTerrain(P, 249, gHands[B.Owner].FlagColor);
+      end;
+
+    end;
+  end
+  else
+    if gMySpectator.Selected is TKMHouseWoodcutters then
+    begin
+      C := TKMHouseWoodcutters(gMySpectator.Selected);
+      P := KMPointF(C.CuttingPoint.X - 0.5, C.CuttingPoint.Y - 0.5);
+      if C.IsCuttingPointSet then
+      begin
+        case aPass of
+          0: begin
+               AddAlert(P, 249, gHands[C.Owner].FlagColor);
+               gRenderAux.LineOnTerrain(C.GetEntrance.X - 0.5, C.GetEntrance.Y - 0.5, P.X, P.Y, gHands[C.Owner].FlagColor, $F0F0, False);
+               gRenderAux.CircleOnTerrain(P.X, P.Y, gRes.UnitDat[ut_Woodcutter].MiningRange, gHands[C.Owner].FlagColor - $CC000000, gHands[C.Owner].FlagColor);
+             end;
+          1: if gMySpectator.FogOfWar.CheckRevelation(P) < FOG_OF_WAR_MAX then
+               fRenderPool.RenderSpriteOnTerrain(P, 249, gHands[C.Owner].FlagColor);
+        end;
+      end;
     end;
 
-  end;
 end;
 
 

--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -370,8 +370,6 @@ var
   B: TKMHouseBarracks;
   C: TKMHouseWoodcutters;
   P: TKMPointF;
-  PcPrev, PcNext: TKMPointF;
-  i: Integer;
 begin
   if gGame.IsMapEditor then Exit; // Don't render rally point in map editor
   if not (gMySpectator.Selected is TKMHouseBarracks) and not (gMySpectator.Selected is TKMHouseWoodcutters) then
@@ -391,28 +389,25 @@ begin
         1: if gMySpectator.FogOfWar.CheckRevelation(P) < FOG_OF_WAR_MAX then
              fRenderPool.RenderSpriteOnTerrain(P, 249, gHands[B.Owner].FlagColor);
       end;
-
     end;
   end
   else
     if gMySpectator.Selected is TKMHouseWoodcutters then
     begin
       C := TKMHouseWoodcutters(gMySpectator.Selected);
-      P := KMPointF(C.CuttingPoint.X - 0.5, C.CuttingPoint.Y - 0.5);
       if C.IsCuttingPointSet then
       begin
+        P := KMPointF(C.CuttingPoint.X - 0.5, C.CuttingPoint.Y - 0.5);
         case aPass of
           0: begin
-               AddAlert(P, 249, gHands[C.Owner].FlagColor);
+               AddAlert(P, 660, gHands[C.Owner].FlagColor);
                gRenderAux.LineOnTerrain(C.GetEntrance.X - 0.5, C.GetEntrance.Y - 0.5, P.X, P.Y, gHands[C.Owner].FlagColor, $F0F0, False);
-               gRenderAux.CircleOnTerrain(P.X, P.Y, gRes.UnitDat[ut_Woodcutter].MiningRange, gHands[C.Owner].FlagColor - $CC000000, gHands[C.Owner].FlagColor);
              end;
           1: if gMySpectator.FogOfWar.CheckRevelation(P) < FOG_OF_WAR_MAX then
-               fRenderPool.RenderSpriteOnTerrain(P, 249, gHands[C.Owner].FlagColor);
+             fRenderPool.RenderSpriteOnTerrain(P, 660, gHands[C.Owner].FlagColor);
         end;
       end;
     end;
-
 end;
 
 
@@ -1692,3 +1687,4 @@ end;
 
 
 end.
+

--- a/src/scripting/KM_ScriptingActions.pas
+++ b/src/scripting/KM_ScriptingActions.pas
@@ -136,7 +136,7 @@ type
 
 implementation
 uses
-  KM_AI, KM_Terrain, KM_Game, KM_FogOfWar, KM_HandsCollection, KM_Units_Warrior, KM_Deliveries,
+  KM_AI, KM_Terrain, KM_Game, KM_FogOfWar, KM_HandsCollection, KM_Units_Warrior, KM_HandLogistics,
   KM_HouseBarracks, KM_HouseSchool, KM_ResUnits, KM_Log, KM_Utils, KM_HouseMarket,
   KM_Resource, KM_UnitTaskSelfTrain, KM_Sound, KM_Hand, KM_AIDefensePos, KM_CommonClasses,
   KM_UnitsCollection, KM_PathFindingRoad;

--- a/src/units/KM_UnitTaskBuild.pas
+++ b/src/units/KM_UnitTaskBuild.pas
@@ -119,7 +119,7 @@ type
 
 implementation
 uses
-  KM_Deliveries, KM_HandsCollection, KM_Resource, KM_ResMapElements, KM_ResWares, KM_Game, KM_Hand;
+  KM_HandLogistics, KM_HandsCollection, KM_Resource, KM_ResMapElements, KM_ResWares, KM_Game, KM_Hand;
 
 
 { TTaskBuildRoad }

--- a/src/units/KM_Units_Warrior.pas
+++ b/src/units/KM_Units_Warrior.pas
@@ -96,7 +96,7 @@ type
 
 implementation
 uses
-  KM_ResTexts, KM_HandsCollection, KM_RenderPool, KM_RenderAux, KM_UnitTaskAttackHouse, KM_Deliveries,
+  KM_ResTexts, KM_HandsCollection, KM_RenderPool, KM_RenderAux, KM_UnitTaskAttackHouse, KM_HandLogistics,
   KM_UnitActionAbandonWalk, KM_UnitActionFight, KM_UnitActionGoInOut, KM_UnitActionWalkTo, KM_UnitActionStay,
   KM_UnitActionStormAttack, KM_Resource, KM_ResUnits, KM_Hand,
   KM_ResWares, KM_Game, KM_ResHouses;

--- a/src/units/KM_Units_WorkPlan.pas
+++ b/src/units/KM_Units_WorkPlan.pas
@@ -238,7 +238,7 @@ begin
     ut_Woodcutter:    if aHome = ht_Woodcutters then
                       begin
                         if TKMHouseWoodcutters(aUnit.GetHome).IsCuttingPointSet then
-                          aLoc := KMPointBelow(TKMHouseWoodcutters(aUnit.GetHome).CuttingPoint);
+                          aLoc := TKMHouseWoodcutters(aUnit.GetHome).CuttingPoint;
                         fIssued := ChooseTree(aLoc, KMPoint(0,0), gRes.UnitDat[aUnit.UnitType].MiningRange, aPlantAct, aUnit, Tmp, PlantAct);
                         if fIssued then
                         begin

--- a/src/units/KM_Units_WorkPlan.pas
+++ b/src/units/KM_Units_WorkPlan.pas
@@ -53,7 +53,7 @@ type
 
 implementation
 uses
-  KM_Resource, KM_Utils, KM_Hand, KM_ResUnits;
+  KM_Resource, KM_Utils, KM_Hand, KM_ResUnits, KM_Houses;
 
 
 {Houses are only a place on map, they should not issue or perform tasks (except Training)
@@ -237,6 +237,8 @@ begin
   case aUnit.UnitType of
     ut_Woodcutter:    if aHome = ht_Woodcutters then
                       begin
+                        if TKMHouseWoodcutters(aUnit.GetHome).IsCuttingPointSet then
+                          aLoc := KMPointBelow(TKMHouseWoodcutters(aUnit.GetHome).CuttingPoint);
                         fIssued := ChooseTree(aLoc, KMPoint(0,0), gRes.UnitDat[aUnit.UnitType].MiningRange, aPlantAct, aUnit, Tmp, PlantAct);
                         if fIssued then
                         begin


### PR DESCRIPTION
Added hotkeys on Train button:
Shift+Left mouse btn - train unit immidiately. If other unit is
training, cancel it, move to pos 1 in queue, train current unit.
Ctrl+Left mouse btn - add unit in queue on 1st position (it will be
trained after current training unit)
In the queue bar same hotkeys were added: Shift+LMB - immidiate train.
Ctrl+LMB put 1st in queue.