### PR TITLE
Ability to change school training order

### DIFF
--- a/src/KM_GameInputProcess.pas
+++ b/src/KM_GameInputProcess.pas
@@ -63,6 +63,7 @@ type
     gic_HouseStoreAcceptFlag,     //Control wares delivery to store
     gic_HouseSchoolTrain,         //Place an order to train citizen
     gic_HouseSchoolTrainChOrder,  //Change school training order
+    gic_HouseSchoolTrainChLastUOrder,  //Change school training order for last unit in queue
     gic_HouseBarracksAcceptFlag,  //Control wares delivery to barracks
     gic_HouseBarracksEquip,       //Place an order to train warrior
     gic_HouseBarracksRally,       //Set the rally point for the barracks
@@ -312,7 +313,8 @@ begin
     if CommandType in [gic_HouseRepairToggle, gic_HouseDeliveryToggle, gic_HouseWoodcuttersCutting,
       gic_HouseOrderProduct, gic_HouseMarketFrom, gic_HouseMarketTo, gic_HouseBarracksRally,
       gic_HouseStoreAcceptFlag, gic_HouseBarracksAcceptFlag, gic_HouseBarracksEquip,
-      gic_HouseSchoolTrain, gic_HouseSchoolTrainChOrder, gic_HouseRemoveTrain, gic_HouseWoodcutterMode] then
+      gic_HouseSchoolTrain, gic_HouseSchoolTrainChOrder, gic_HouseSchoolTrainChLastUOrder, gic_HouseRemoveTrain,
+      gic_HouseWoodcutterMode] then
     begin
       SrcHouse := gHands.GetHouseByUID(Params[1]);
       if (SrcHouse = nil) or SrcHouse.IsDestroyed //House has been destroyed before command could be executed
@@ -368,6 +370,7 @@ begin
       gic_HouseBarracksRally:     TKMHouseBarracks(SrcHouse).RallyPoint := KMPoint(Params[2], Params[3]);
       gic_HouseSchoolTrain:       TKMHouseSchool(SrcHouse).AddUnitToQueue(TUnitType(Params[2]), Params[3]);
       gic_HouseSchoolTrainChOrder:TKMHouseSchool(SrcHouse).ChangeUnitTrainOrder(Params[2], Params[3]);
+      gic_HouseSchoolTrainChLastUOrder: TKMHouseSchool(SrcHouse).ChangeUnitTrainOrder(Params[2]);
       gic_HouseRemoveTrain:       TKMHouseSchool(SrcHouse).RemUnitFromQueue(Params[2]);
       gic_HouseWoodcuttersCutting: TKMHouseWoodcutters(SrcHouse).CuttingPoint := KMPoint(Params[2], Params[3]);
 
@@ -539,7 +542,7 @@ end;
 
 procedure TGameInputProcess.CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aItem:integer);
 begin
-  Assert(aCommandType = gic_HouseRemoveTrain);
+  Assert(aCommandType in [gic_HouseRemoveTrain, gic_HouseSchoolTrainChLastUOrder]);
   Assert(aHouse is TKMHouseSchool);
   TakeCommand(MakeCommand(aCommandType, [aHouse.UID, aItem]));
 end;

--- a/src/KM_GameInputProcess.pas
+++ b/src/KM_GameInputProcess.pas
@@ -62,6 +62,7 @@ type
     gic_HouseWoodcutterMode,      //Switch the woodcutter mode
     gic_HouseStoreAcceptFlag,     //Control wares delivery to store
     gic_HouseSchoolTrain,         //Place an order to train citizen
+    gic_HouseSchoolTrainChOrder,  //Change school training order
     gic_HouseBarracksAcceptFlag,  //Control wares delivery to barracks
     gic_HouseBarracksEquip,       //Place an order to train warrior
     gic_HouseBarracksRally,       //Set the rally point for the barracks
@@ -311,7 +312,7 @@ begin
     if CommandType in [gic_HouseRepairToggle, gic_HouseDeliveryToggle, gic_HouseWoodcuttersCutting,
       gic_HouseOrderProduct, gic_HouseMarketFrom, gic_HouseMarketTo, gic_HouseBarracksRally,
       gic_HouseStoreAcceptFlag, gic_HouseBarracksAcceptFlag, gic_HouseBarracksEquip,
-      gic_HouseSchoolTrain, gic_HouseRemoveTrain, gic_HouseWoodcutterMode] then
+      gic_HouseSchoolTrain, gic_HouseSchoolTrainChOrder, gic_HouseRemoveTrain, gic_HouseWoodcutterMode] then
     begin
       SrcHouse := gHands.GetHouseByUID(Params[1]);
       if (SrcHouse = nil) or SrcHouse.IsDestroyed //House has been destroyed before command could be executed
@@ -366,6 +367,7 @@ begin
       gic_HouseBarracksEquip:     TKMHouseBarracks(SrcHouse).Equip(TUnitType(Params[2]), Params[3]);
       gic_HouseBarracksRally:     TKMHouseBarracks(SrcHouse).RallyPoint := KMPoint(Params[2], Params[3]);
       gic_HouseSchoolTrain:       TKMHouseSchool(SrcHouse).AddUnitToQueue(TUnitType(Params[2]), Params[3]);
+      gic_HouseSchoolTrainChOrder:TKMHouseSchool(SrcHouse).ChangeUnitTrainOrder(Params[2], Params[3]);
       gic_HouseRemoveTrain:       TKMHouseSchool(SrcHouse).RemUnitFromQueue(Params[2]);
       gic_HouseWoodcuttersCutting: TKMHouseWoodcutters(SrcHouse).CuttingPoint := KMPoint(Params[2], Params[3]);
 
@@ -509,7 +511,7 @@ end;
 
 procedure TGameInputProcess.CmdHouse(aCommandType: TGameInputCommandType; aHouse: TKMHouse; aItem, aAmountChange: Integer);
 begin
-  Assert(aCommandType = gic_HouseOrderProduct);
+  Assert(aCommandType in [gic_HouseOrderProduct, gic_HouseSchoolTrainChOrder]);
   TakeCommand(MakeCommand(aCommandType, [aHouse.UID, aItem, aAmountChange]));
 end;
 

--- a/src/gui/pages_game/KM_GUIGameHouse.pas
+++ b/src/gui/pages_game/KM_GUIGameHouse.pas
@@ -33,7 +33,7 @@ type
     procedure House_MarketSelect(Sender: TObject; Shift: TShiftState);
 
     procedure House_SchoolUnitChange(Sender: TObject; Shift: TShiftState);
-    procedure House_SchoolUnitRemove(Sender: TObject; Shift: TShiftState);
+    procedure House_SchoolUnitBarPressed(Sender: TObject; Shift: TShiftState);
 
     procedure House_StoreAcceptFlag(Sender: TObject);
     procedure House_StoreFill;
@@ -289,13 +289,13 @@ begin
     Button_School_UnitWIP := TKMButton.Create(Panel_House_School,  0,48,32,32,0, rxGui, bsGame);
     Button_School_UnitWIP.Hint := gResTexts[TX_HOUSE_SCHOOL_WIP_HINT];
     Button_School_UnitWIP.Tag := 0;
-    Button_School_UnitWIP.OnClickShift := House_SchoolUnitRemove;
+    Button_School_UnitWIP.OnClickShift := House_SchoolUnitBarPressed;
     Button_School_UnitWIPBar := TKMPercentBar.Create(Panel_House_School,34,54,146,20);
     for I := 1 to 5 do
     begin
       Button_School_UnitPlan[i] := TKMButtonFlat.Create(Panel_House_School, (I-1) * 36, 80, 32, 32, 0);
       Button_School_UnitPlan[i].Tag := I;
-      Button_School_UnitPlan[i].OnClickShift := House_SchoolUnitRemove;
+      Button_School_UnitPlan[i].OnClickShift := House_SchoolUnitBarPressed;
     end;
 
     Label_School_Unit := TKMLabel.Create(Panel_House_School,   0,116,TB_WIDTH,30,'',fnt_Outline,taCenter);
@@ -817,7 +817,7 @@ end;
 {Process click on Left-Train-Right buttons of School}
 procedure TKMGUIGameHouse.House_SchoolUnitChange(Sender: TObject; Shift: TShiftState);
 var
-  I: Byte;
+  I, ChOrderFrom: Byte;
   School: TKMHouseSchool;
 begin
   if gMySpectator.Selected = nil then exit;
@@ -831,7 +831,19 @@ begin
   if (Sender = Button_School_Right) and (fLastSchoolUnit < High(School_Order)) then Inc(fLastSchoolUnit);
 
   if Sender = Button_School_Train then //Add unit to training queue
-    gGame.GameInputProcess.CmdHouse(gic_HouseSchoolTrain, School, School_Order[fLastSchoolUnit], GetMultiplicator(Shift));
+  begin
+    if (ssRight in Shift) then
+      gGame.GameInputProcess.CmdHouse(gic_HouseSchoolTrain, School, School_Order[fLastSchoolUnit], 10)
+    else if (ssLeft in Shift) then
+    begin
+      gGame.GameInputProcess.CmdHouse(gic_HouseSchoolTrain, School, School_Order[fLastSchoolUnit], 1);
+      ChOrderFrom := max(School.LastUnitPosInQueue, 1);
+      if (ssShift in Shift) then
+        gGame.GameInputProcess.CmdHouse(gic_HouseSchoolTrainChOrder, School, ChOrderFrom, 0)
+      else if ssCtrl in Shift then
+        gGame.GameInputProcess.CmdHouse(gic_HouseSchoolTrainChOrder, School, ChOrderFrom, 1);
+    end;
+  end;
 
   if School.Queue[0] <> ut_None then
     Button_School_UnitWIP.TexID := gRes.UnitDat[School.Queue[0]].GUIIcon
@@ -876,8 +888,8 @@ begin
 end;
 
 
-{Process click on Remove-from-queue buttons of School}
-procedure TKMGUIGameHouse.House_SchoolUnitRemove(Sender: TObject; Shift: TShiftState);
+{Process click on Units bar buttons of School}
+procedure TKMGUIGameHouse.House_SchoolUnitBarPressed(Sender: TObject; Shift: TShiftState);
 var
   School: TKMHouseSchool;
   I, id: Integer;
@@ -887,12 +899,15 @@ begin
 
   //Right click clears entire queue after this item.
   //In that case we remove the same id repeatedly because they're automatically move along
-  if ssLeft in Shift then
-    gGame.GameInputProcess.CmdHouse(gic_HouseRemoveTrain, School, id)
-  else
   if ssRight in Shift then
     for I := School.QueueLength - 1 downto id do
-      gGame.GameInputProcess.CmdHouse(gic_HouseRemoveTrain, School, I);
+      gGame.GameInputProcess.CmdHouse(gic_HouseRemoveTrain, School, I)
+  else if (ssShift in Shift) then
+    gGame.GameInputProcess.CmdHouse(gic_HouseSchoolTrainChOrder, School, id, 0)
+  else if ssCtrl in Shift then
+    gGame.GameInputProcess.CmdHouse(gic_HouseSchoolTrainChOrder, School, id, min(id,1))
+  else
+    gGame.GameInputProcess.CmdHouse(gic_HouseRemoveTrain, School, id);
 
   House_SchoolUnitChange(nil, []);
 end;

--- a/src/houses/KM_HouseSchool.pas
+++ b/src/houses/KM_HouseSchool.pas
@@ -26,7 +26,8 @@ type
     procedure DemolishHouse(aFrom: TKMHandIndex; IsSilent: Boolean = False); override;
     procedure ResAddToIn(aWare: TWareType; aCount: Word = 1; aFromScript: Boolean = False); override;
     function AddUnitToQueue(aUnit: TUnitType; aCount: Byte): Byte; //Should add unit to queue if there's a place
-    procedure ChangeUnitTrainOrder(aOldPosition, aNewPosition: Integer); //Change unit order in queue
+    procedure ChangeUnitTrainOrder(aNewPosition: Integer); overload; //Change last unit in queue training order
+    procedure ChangeUnitTrainOrder(aOldPosition, aNewPosition: Integer); overload; //Change unit order in queue
     procedure RemUnitFromQueue(aID: Byte); //Should remove unit from queue and shift rest up
     procedure UnitTrainingComplete(aUnit: Pointer); //This should shift queue filling rest with ut_None
     function GetTrainingProgress: Single;
@@ -129,6 +130,12 @@ begin
   end;
   fUnitWip := nil;
   fQueue[0] := ut_None; //Removed the in training unit
+end;
+
+//Change unit priority in training queue
+procedure TKMHouseSchool.ChangeUnitTrainOrder(aNewPosition: Integer);
+begin
+  ChangeUnitTrainOrder(max(LastUnitPosInQueue, 1), aNewPosition);
 end;
 
 //Change unit priority in training queue
@@ -268,7 +275,7 @@ end;
 
 function TKMHouseSchool.QueueCount: Byte;
 var
-  I: Byte;
+  I: Integer;
 begin
   Result := 0;
   for I := 0 to High(fQueue) do
@@ -277,6 +284,8 @@ begin
 end;
 
 
+// Returns position of the last unit in queue.
+// If queue is empty, return -1
 function TKMHouseSchool.LastUnitPosInQueue: Integer;
 var I: Integer;
 begin
@@ -284,8 +293,6 @@ begin
   for I := 0 to High(fQueue) do
     if fQueue[I] <> ut_None then
       Result := I
-    else
-      Continue
 end;
 
 

--- a/src/houses/KM_HouseSchool.pas
+++ b/src/houses/KM_HouseSchool.pas
@@ -268,7 +268,7 @@ end;
 
 function TKMHouseSchool.QueueCount: Byte;
 var
-  I: Byte;
+  I: Integer;
 begin
   Result := 0;
   for I := 0 to High(fQueue) do
@@ -284,8 +284,6 @@ begin
   for I := 0 to High(fQueue) do
     if fQueue[I] <> ut_None then
       Result := I
-    else
-      Continue
 end;
 
 

--- a/src/houses/KM_HouseSchool.pas
+++ b/src/houses/KM_HouseSchool.pas
@@ -16,7 +16,9 @@ type
     fTrainProgress: Byte; //Was it 150 steps in KaM?
     fQueue: array [0..5] of TUnitType;
     function GetQueue(aIndex: Integer): TUnitType; //Used in UI. First item is the unit currently being trained, 1..5 are the actual queue
+    procedure CreateUnit; //This should Create new unit and start training cycle
     procedure StartTrainingUnit; //This should Create new unit and start training cycle
+    procedure CancelTrainingUnit;
   public
     constructor Create(aUID: Integer; aHouseType: THouseType; PosX, PosY: Integer; aOwner: TKMHandIndex; aBuildState: THouseBuildState);
     constructor Load(LoadStream: TKMemoryStream); override;
@@ -24,10 +26,12 @@ type
     procedure DemolishHouse(aFrom: TKMHandIndex; IsSilent: Boolean = False); override;
     procedure ResAddToIn(aWare: TWareType; aCount: Word = 1; aFromScript: Boolean = False); override;
     function AddUnitToQueue(aUnit: TUnitType; aCount: Byte): Byte; //Should add unit to queue if there's a place
+    procedure ChangeUnitTrainOrder(aOldPosition, aNewPosition: Integer); //Change unit order in queue
     procedure RemUnitFromQueue(aID: Byte); //Should remove unit from queue and shift rest up
     procedure UnitTrainingComplete(aUnit: Pointer); //This should shift queue filling rest with ut_None
     function GetTrainingProgress: Single;
     function QueueCount: Byte;
+    function LastUnitPosInQueue: Integer;
     function QueueIsEmpty: Boolean;
     function QueueIsFull: Boolean;
     function QueueLength: Byte;
@@ -115,6 +119,52 @@ begin
 end;
 
 
+procedure TKMHouseSchool.CancelTrainingUnit;
+begin
+  SetState(hst_Idle);
+  if fUnitWip <> nil then
+  begin //Make sure unit started training
+    TKMUnit(fUnitWip).CloseUnit(False); //Don't remove tile usage, we are inside the school
+    fHideOneGold := False;
+  end;
+  fUnitWip := nil;
+  fQueue[0] := ut_None; //Removed the in training unit
+end;
+
+//Change unit priority in training queue
+procedure TKMHouseSchool.ChangeUnitTrainOrder(aOldPosition, aNewPosition: Integer);
+var tmpUnit: TUnitType;
+  I: Byte;
+begin
+  Assert((aNewPosition >= 0) and (aOldPosition <= 5));
+
+  if aOldPosition = 0 then Exit;
+
+  // Do not cancel current training process, if unit type is the same.
+  // Or set newPos to 1, if there is no training now (no gold, for example)
+  if (aNewPosition = 0) and ((fQueue[aOldPosition] = fQueue[0]) or (fQueue[0] = ut_None)) then
+    aNewPosition := 1;
+
+  if (fQueue[aOldPosition] = ut_None) or (aOldPosition = aNewPosition) then Exit;
+
+  Assert(aNewPosition < aOldPosition);
+
+  tmpUnit := fQueue[aOldPosition];
+  for I := aOldPosition downto max(aNewPosition, 0)+1 do
+  begin
+    fQueue[I] := fQueue[I-1];
+  end;
+
+  if (aNewPosition = 0) then
+    CancelTrainingUnit;
+
+  fQueue[aNewPosition] := tmpUnit;
+
+  if (aNewPosition = 0) then
+    CreateUnit;
+end;
+
+
 //DoCancelTraining and remove untrained unit
 procedure TKMHouseSchool.RemUnitFromQueue(aID: Byte);
 var
@@ -124,14 +174,7 @@ begin
 
   if aID = 0 then
   begin
-    SetState(hst_Idle);
-    if fUnitWip <> nil then
-    begin //Make sure unit started training
-      TKMUnit(fUnitWip).CloseUnit(False); //Don't remove tile usage, we are inside the school
-      fHideOneGold := False;
-    end;
-    fUnitWip := nil;
-    fQueue[0] := ut_None; //Removed the in training unit
+    CancelTrainingUnit;
     StartTrainingUnit; //Start on the next unit in the queue
   end
   else
@@ -143,6 +186,18 @@ begin
 end;
 
 
+procedure TKMHouseSchool.CreateUnit;
+begin
+  fHideOneGold := true;
+
+  //Create the Unit
+  fUnitWip := gHands[fOwner].TrainUnit(fQueue[0], GetEntrance);
+  TKMUnit(fUnitWip).TrainInHouse(Self); //Let the unit start the training task
+
+  WorkAnimStep := 0;
+end;
+
+
 procedure TKMHouseSchool.StartTrainingUnit;
 var I: Integer;
 begin
@@ -150,16 +205,11 @@ begin
   if fQueue[1] = ut_None then exit; //If there is a unit waiting to be trained
   if CheckResIn(wt_Gold) = 0 then exit; //There must be enough gold to perform training
 
-  fHideOneGold := true;
   for I := 0 to High(fQueue) - 1 do
     fQueue[I] := fQueue[I+1]; //Shift by one
   fQueue[High(fQueue)] := ut_None; //Set the last one empty
 
-  //Create the Unit
-  fUnitWip := gHands[fOwner].TrainUnit(fQueue[0], GetEntrance);
-  TKMUnit(fUnitWip).TrainInHouse(Self); //Let the unit start the training task
-
-  WorkAnimStep := 0;
+  CreateUnit;
 end;
 
 
@@ -218,12 +268,24 @@ end;
 
 function TKMHouseSchool.QueueCount: Byte;
 var
-  I: Integer;
+  I: Byte;
 begin
   Result := 0;
   for I := 0 to High(fQueue) do
     if fQueue[I] <> ut_None then
       Inc(Result);
+end;
+
+
+function TKMHouseSchool.LastUnitPosInQueue: Integer;
+var I: Integer;
+begin
+  Result := -1;
+  for I := 0 to High(fQueue) do
+    if fQueue[I] <> ut_None then
+      Result := I
+    else
+      Continue
 end;
 
 


### PR DESCRIPTION
When clicked on train btn: 
Shift+LMB - train immediately (cancel current training)
Ctrl+LMB - train next (put on 1st position in queue)
Same behaviour when clicking in the training queue bar