### PR TITLE
Update Buglist due to PR #98

### DIFF
--- a/Todo/Buglist.txt
+++ b/Todo/Buglist.txt
@@ -75,7 +75,6 @@ Improvements:
 	L	Icon before the server name: Swords/house/floppy for battle/build/save (save icon only shown while in lobby)
 	L	Maplist takes too long to load on first run, scrollbar moves irritatingly while maps are being added
 	L	Save last selected item in lists (load game, mp, maped list, savegames, etc)
-	L	Right-click on a unit in Schools queue to move that unit to the front of the queue (currently RMB is "remove to here")
 	M	Archers should not change formations when group members get killed while under attack
 	L	Allow to block wares delivery into armor workshop, so that player could focus each on certain task (shields or armors)
 	L	Keep road bends when neighbour road is destroyed (e.g. house entrances)


### PR DESCRIPTION
line deleted:
Right-click on a unit in Schools queue to move that unit to the front of the queue (currently RMB is "remove to here")