### PR TITLE
New feature: current game window position/size/state saved to ini file and restored on startUp

### DIFF
--- a/src/KM_FormMain.pas
+++ b/src/KM_FormMain.pas
@@ -596,12 +596,12 @@ begin
                       Wp.length := SizeOf(TWindowPlacement);
                       GetWindowPlacement(Handle, @Wp);
 
-                      // Get current border width/height
+                      // Get current borders width/height
                       BordersWidth := Width - ClientWidth;
                       BordersHeight := Height - ClientHeight;
 
                       // rcNormalPosition do not have ClientWidth/ClientHeight
-                      // so we have to calc it manually via substracting border width/height
+                      // so we have to calc it manually via substracting borders width/height
                       Result.Width := Wp.rcNormalPosition.Right - Wp.rcNormalPosition.Left - BordersWidth;
                       Result.Height := Wp.rcNormalPosition.Bottom - Wp.rcNormalPosition.Top - BordersHeight;
 

--- a/src/KM_FormMain.pas
+++ b/src/KM_FormMain.pas
@@ -575,6 +575,7 @@ begin
   RenderArea.Align := alClient;
 end;
 
+
 // Return current window params
 function TFormMain.GetWindowParams: TKMWindowParamsRecord;
   // FindTaskBar returns the Task Bar's position, and fills in
@@ -659,7 +660,6 @@ procedure TFormMain.WMExitSizeMove(var Msg: TMessage) ;
 begin
   fMain.Move(GetWindowParams);
 end;
-
 
 
 procedure TFormMain.Debug_ExportMenuClick(Sender: TObject);

--- a/src/KM_Main.pas
+++ b/src/KM_Main.pas
@@ -300,7 +300,6 @@ end;
 
 procedure TKMMain.ReinitRender(aReturnToOptions: Boolean);
 begin
-
   if fMainSettings.FullScreen then
   begin
     // Lock window params while we are in FullScreen mode

--- a/src/KM_Main.pas
+++ b/src/KM_Main.pas
@@ -34,7 +34,9 @@ type
     procedure CloseQuery(var CanClose: Boolean);
     procedure Stop(Sender: TObject);
 
-    procedure Resize(X,Y: Integer);
+    procedure UpdateWindowParams(aWindowParams: TKMWindowParams);
+    procedure Resize(aWidth, aHeight: Integer); overload;
+    procedure Resize(aWidth, aHeight: Integer; aWindowParams: TKMWindowParams); overload;
     procedure Render;
     procedure ShowAbout;
     property FormMain: TFormMain read fFormMain;
@@ -484,10 +486,27 @@ begin
 end;
 
 
-procedure TKMMain.Resize(X, Y: Integer);
+procedure TKMMain.UpdateWindowParams(aWindowParams: TKMWindowParams);
 begin
   if gGameApp <> nil then
-    gGameApp.Resize(X, Y);
+    fMainSettings.WindowParams := aWindowParams;
+
+end;
+
+procedure TKMMain.Resize(aWidth, aHeight: Integer);
+begin
+  if gGameApp <> nil then
+    gGameApp.Resize(aWidth, aHeight);
+end;
+
+
+procedure TKMMain.Resize(aWidth, aHeight: Integer; aWindowParams: TKMWindowParams);
+begin
+  if gGameApp <> nil then
+  begin
+    gGameApp.Resize(aWidth, aHeight);
+    UpdateWindowParams(aWindowParams);
+  end;
 end;
 
 

--- a/src/KM_Resolutions.pas
+++ b/src/KM_Resolutions.pas
@@ -2,7 +2,7 @@ unit KM_Resolutions;
 {$I KaM_Remake.inc}
 interface
 uses
-  Classes, Math, SysUtils, Forms,
+  Classes, Math, SysUtils,
   {$IFDEF MSWindows} Windows, {$ENDIF}
   KM_Defaults;
 

--- a/src/KM_Resolutions.pas
+++ b/src/KM_Resolutions.pas
@@ -11,7 +11,6 @@ type
     Width, Height, RefRate: SmallInt;
   end;
 
-
   TKMScreenResIndex = record
     ResId, RefId: Integer;
   end;

--- a/src/KM_Resolutions.pas
+++ b/src/KM_Resolutions.pas
@@ -11,25 +11,6 @@ type
     Width, Height, RefRate: SmallInt;
   end;
 
-  TKMWindowState = (ws_Normal, ws_Maximized);
-
-//  TKMWindowParams = class
-//  private
-//    fWidth, fHeight, fLeft, fTop: SmallInt;
-//    fState: TKMWindowState;
-//  public
-//    property Width: SmallInt read fWidth write fWidth;
-//    property Height: SmallInt read fHeight write fHeight;
-//    property Left: SmallInt read fLeft write fLeft;
-//    property Top: SmallInt read fTop write fTop;
-//    property State:
-//  end;
-
-  TKMWindowParams = record
-    Width, Height, Left, Top: SmallInt;
-    State: TWindowState;
-  end;
-
 
   TKMScreenResIndex = record
     ResId, RefId: Integer;

--- a/src/KM_Resolutions.pas
+++ b/src/KM_Resolutions.pas
@@ -2,7 +2,7 @@ unit KM_Resolutions;
 {$I KaM_Remake.inc}
 interface
 uses
-  Classes, Math, SysUtils,
+  Classes, Math, SysUtils, Forms,
   {$IFDEF MSWindows} Windows, {$ENDIF}
   KM_Defaults;
 
@@ -10,6 +10,26 @@ type
   TKMScreenRes = record
     Width, Height, RefRate: SmallInt;
   end;
+
+  TKMWindowState = (ws_Normal, ws_Maximized);
+
+//  TKMWindowParams = class
+//  private
+//    fWidth, fHeight, fLeft, fTop: SmallInt;
+//    fState: TKMWindowState;
+//  public
+//    property Width: SmallInt read fWidth write fWidth;
+//    property Height: SmallInt read fHeight write fHeight;
+//    property Left: SmallInt read fLeft write fLeft;
+//    property Top: SmallInt read fTop write fTop;
+//    property State:
+//  end;
+
+  TKMWindowParams = record
+    Width, Height, Left, Top: SmallInt;
+    State: TWindowState;
+  end;
+
 
   TKMScreenResIndex = record
     ResId, RefId: Integer;

--- a/src/KM_Settings.pas
+++ b/src/KM_Settings.pas
@@ -270,7 +270,6 @@ begin
 end;
 
 
-
 procedure TMainSettings.SetVSync(aValue: boolean);
 begin
   fVSync := aValue;
@@ -665,7 +664,7 @@ begin
   // Do not let put window too much left or right. 100px is enought to get it back in that case
   Result := (fLeft > -fWidth + 100)
         and (fLeft < ScreenMaxWidth - 100)
-        and (fTop > 0)
+        and (fTop >= 0)
         and (fTop < ScreenMaxHeight - 100)
         and (fWidth >= MIN_RESOLUTION_WIDTH)
         and (fWidth <= ScreenMaxWidth)

--- a/src/KM_Settings.pas
+++ b/src/KM_Settings.pas
@@ -2,7 +2,7 @@
 {$I KaM_Remake.inc}
 interface
 uses
-  Classes, SysUtils, Math, INIfiles,
+  Classes, SysUtils, Math, INIfiles, Forms,
   KM_Defaults, KM_Resolutions;
 
 
@@ -15,9 +15,11 @@ type
 
     fFullScreen: Boolean;
     fResolution: TKMScreenRes;
+    fWindowParams: TKMWindowParams;
     fVSync: Boolean;
     procedure SetFullScreen(aValue: Boolean);
     procedure SetResolution(const Value: TKMScreenRes);
+    procedure SetWindowParams(const Value: TKMWindowParams);
     procedure SetVSync(aValue: Boolean);
   protected
     procedure Changed;
@@ -32,6 +34,7 @@ type
 
     property FullScreen: Boolean read fFullScreen write SetFullScreen;
     property Resolution: TKMScreenRes read fResolution write SetResolution;
+    property WindowParams: TKMWindowParams read fWindowParams write SetWindowParams;
     property VSync: Boolean read fVSync write SetVSync;
   end;
 
@@ -180,6 +183,14 @@ begin
   fResolution.Height  := F.ReadInteger('GFX', 'ResolutionHeight', 768);
   fResolution.RefRate := F.ReadInteger('GFX', 'RefreshRate',      60);
 
+  fWindowParams.Width := F.ReadInteger  ('Window', 'WindowWidth',   1024);
+  fWindowParams.Height := F.ReadInteger ('Window', 'WindowHeight',  768);
+  fWindowParams.Left := F.ReadInteger   ('Window', 'WindowLeft',    0);
+  fWindowParams.Top := F.ReadInteger    ('Window', 'WindowTop',     0);
+  fWindowParams.State := TWindowState(F.ReadInteger('Window', 'WindowState',  0));
+
+  //WindowState := TWindowState(GetEnumValue(TypeInfo(TWindowState), wIni.ReadString('FORM', 'WINDOWSTATE', 'wsNormal')));
+
   FreeAndNil(F);
   fNeedsSave := False;
 end;
@@ -198,6 +209,14 @@ begin
   F.WriteInteger('GFX','ResolutionHeight',fResolution.Height);
   F.WriteInteger('GFX','RefreshRate',     fResolution.RefRate);
 
+  F.WriteInteger('Window','WindowWidth', fWindowParams.Width);
+  F.WriteInteger('Window','WindowHeight', fWindowParams.Height);
+  F.WriteInteger('Window','WindowLeft', fWindowParams.Left);
+  F.WriteInteger('Window','WindowTop', fWindowParams.Top);
+  F.WriteInteger('Window','WindowState', Ord(fWindowParams.State));
+
+//  wIni.WriteString('FORM', 'WINDOWSTATE', GetEnumName(TypeInfo(TWindowState), Ord(WindowState)));
+
   F.UpdateFile; //Write changes to file
   FreeAndNil(F);
   fNeedsSave := False;
@@ -213,6 +232,13 @@ end;
 procedure TMainSettings.SetResolution(const Value: TKMScreenRes);
 begin
   fResolution := Value;
+  Changed;
+end;
+
+
+procedure TMainSettings.SetWindowParams(const Value: TKMWindowParams);
+begin
+  fWindowParams := Value;
   Changed;
 end;
 

--- a/src/KM_Settings.pas
+++ b/src/KM_Settings.pas
@@ -52,9 +52,9 @@ type
     fMusicVolume: Single;
     fSoundFXVolume: Single;
     fSpeedPace: Word;
-    fSpeedMedium: Word;
-    fSpeedFast: Word;
-    fSpeedVeryFast: Word;
+    fSpeedMedium: Single;
+    fSpeedFast: Single;
+    fSpeedVeryFast: Single;
     fMultiplayerName: AnsiString;
     fLastIP: string;
     fLastPort: string;
@@ -116,9 +116,9 @@ type
     property MusicVolume: Single read fMusicVolume write SetMusicVolume;
     property SoundFXVolume: Single read fSoundFXVolume write SetSoundFXVolume;
     property SpeedPace: Word read fSpeedPace;
-    property SpeedMedium: Word read fSpeedMedium;
-    property SpeedFast: Word read fSpeedFast;
-    property SpeedVeryFast: Word read fSpeedVeryFast;
+    property SpeedMedium: Single read fSpeedMedium;
+    property SpeedFast: Single read fSpeedFast;
+    property SpeedVeryFast: Single read fSpeedVeryFast;
     property MultiplayerName: AnsiString read fMultiplayerName write SetMultiplayerName;
     property LastIP: string read fLastIP write SetLastIP;
     property LastPort: string read fLastPort write SetLastPort;
@@ -290,9 +290,9 @@ begin
     fScrollSpeed    := F.ReadInteger('Game', 'ScrollSpeed',    10);
     fLocale         := AnsiString(F.ReadString ('Game', 'Locale', UnicodeString(DEFAULT_LOCALE)));
     fSpeedPace      := F.ReadInteger('Game', 'SpeedPace',      100);
-    fSpeedMedium    := F.ReadInteger('Game', 'SpeedMedium',    3);
-    fSpeedFast      := F.ReadInteger('Game', 'SpeedFast',      6);
-    fSpeedVeryFast  := F.ReadInteger('Game', 'SpeedVeryFast',  10);
+    fSpeedMedium    := F.ReadFloat('Game', 'SpeedMedium',    3);
+    fSpeedFast      := F.ReadFloat('Game', 'SpeedFast',      6);
+    fSpeedVeryFast  := F.ReadFloat('Game', 'SpeedVeryFast',  10);
 
     fSoundFXVolume  := F.ReadFloat  ('SFX',  'SFXVolume',      0.5);
     fMusicVolume    := F.ReadFloat  ('SFX',  'MusicVolume',    0.5);
@@ -344,9 +344,9 @@ begin
     F.WriteInteger('Game','ScrollSpeed',  fScrollSpeed);
     F.WriteString ('Game','Locale',       UnicodeString(fLocale));
     F.WriteInteger('Game','SpeedPace',    fSpeedPace);
-    F.WriteInteger('Game','SpeedMedium',  fSpeedMedium);
-    F.WriteInteger('Game','SpeedFast',    fSpeedFast);
-    F.WriteInteger('Game','SpeedVeryFast',fSpeedVeryFast);
+    F.WriteFloat('Game','SpeedMedium',    fSpeedMedium);
+    F.WriteFloat('Game','SpeedFast',      fSpeedFast);
+    F.WriteFloat('Game','SpeedVeryFast',  fSpeedVeryFast);
 
     F.WriteFloat  ('SFX','SFXVolume',     fSoundFXVolume);
     F.WriteFloat  ('SFX','MusicVolume',   fMusicVolume);


### PR DESCRIPTION
work well on muti monitor systems.
Small issue still remains (as it is in r6720) - when user set fullscreen mode on 2nd monitor, then exit game, after start game again game appears on the 1st monitor in fullscreen mode. 
Not going to fix it, cause probably nobody use 2nd monitor full screen mode.