### PR TITLE
Food exchange rates fix

### DIFF
--- a/src/gui/pages_game/KM_GUIGameHouse.pas
+++ b/src/gui/pages_game/KM_GUIGameHouse.pas
@@ -971,11 +971,11 @@ begin
   begin
     Shape_Market_From.Left := ((Byte(aMarket.ResFrom)-1) mod 6) * 31;
     Shape_Market_From.Top := 12 + ((Byte(aMarket.ResFrom)-1) div 6) * MARKET_RES_HEIGHT;
-    Label_Market_In.Caption := Format(gResTexts[TX_HOUSES_MARKET_FROM], [aMarket.RatioFrom]) + ':';
+    Label_Market_In.Caption := Format(gResTexts[TX_HOUSES_MARKET_FROM], [aMarket.RatioFrom]);
     Button_Market_In.TexID := gRes.Wares[aMarket.ResFrom].GUIIcon;
     Button_Market_In.Caption := IntToStr(aMarket.GetResTotal(aMarket.ResFrom));
   end else begin
-    Label_Market_In.Caption := Format(gResTexts[TX_HOUSES_MARKET_FROM],[0]) + ':';
+    Label_Market_In.Caption := Format(gResTexts[TX_HOUSES_MARKET_FROM],[0]);
     Button_Market_In.TexID := gRes.Wares[wt_None].GUIIcon;
     Button_Market_In.Caption := '-';
   end;
@@ -986,11 +986,11 @@ begin
   begin
     Shape_Market_To.Left := ((Byte(aMarket.ResTo)-1) mod 6) * 31;
     Shape_Market_To.Top := 12 + ((Byte(aMarket.ResTo)-1) div 6) * MARKET_RES_HEIGHT;
-    Label_Market_Out.Caption := Format(gResTexts[TX_HOUSES_MARKET_TO], [aMarket.RatioTo]) + ':';
+    Label_Market_Out.Caption := Format(gResTexts[TX_HOUSES_MARKET_TO], [aMarket.RatioTo]);
     Button_Market_Out.Caption := IntToStr(aMarket.GetResTotal(aMarket.ResTo));
     Button_Market_Out.TexID := gRes.Wares[aMarket.ResTo].GUIIcon;
   end else begin
-    Label_Market_Out.Caption := Format(gResTexts[TX_HOUSES_MARKET_TO], [0]) + ':';
+    Label_Market_Out.Caption := Format(gResTexts[TX_HOUSES_MARKET_TO], [0]);
     Button_Market_Out.TexID := gRes.Wares[wt_None].GUIIcon;
     Button_Market_Out.Caption := '-';
   end;

--- a/src/houses/KM_HouseMarket.pas
+++ b/src/houses/KM_HouseMarket.pas
@@ -18,6 +18,7 @@ type
     procedure AttemptExchange;
     procedure SetResFrom(aRes: TWareType);
     procedure SetResTo(aRes: TWareType);
+    procedure CalcRatioCosts(var aCostFrom, aCostTo: Single);
   protected
     function GetResOrder(aId: Byte): Integer; override;
     procedure SetResOrder(aId: Byte; aValue: Integer); override;
@@ -97,14 +98,26 @@ begin
 end;
 
 
+procedure TKMHouseMarket.CalcRatioCosts(var aCostFrom, aCostTo: Single);
+const TRADE_FROM_FOOD_COEF = 2;
+begin
+  //When trading target ware is priced higher
+    aCostFrom := gRes.Wares[fResFrom].MarketPrice;
+    aCostTo := gRes.Wares[fResTo].MarketPrice * MARKET_TRADEOFF_FACTOR;
+    // Fix trade starting food to other goods to get weapons (actual in low PT games)
+    // Trading from food 2 times less profitable
+    if (fResFrom in WARE_FOOD) 
+      and not (fResTo in WARE_FOOD) then      // Food to food trading is not punished
+      aCostTo := aCostTo * TRADE_FROM_FOOD_COEF;
+end;
+
+
 function TKMHouseMarket.RatioFrom: Byte;
 var CostFrom, CostTo: Single;
 begin
   if (fResFrom <> wt_None) and (fResTo <> wt_None) then
   begin
-    //When trading target ware is priced higher
-    CostFrom := gRes.Wares[fResFrom].MarketPrice;
-    CostTo := gRes.Wares[fResTo].MarketPrice * MARKET_TRADEOFF_FACTOR;
+    CalcRatioCosts(CostFrom, CostTo);
     Result := Round(CostTo / Min(CostFrom, CostTo));
   end else
     Result := 1;
@@ -116,9 +129,7 @@ var CostFrom, CostTo: Single;
 begin
   if (fResFrom <> wt_None) and (fResTo <> wt_None) then
   begin
-    //When trading target ware is priced higher
-    CostFrom := gRes.Wares[fResFrom].MarketPrice;
-    CostTo := gRes.Wares[fResTo].MarketPrice * MARKET_TRADEOFF_FACTOR;
+    CalcRatioCosts(CostFrom, CostTo);
     Result := Round(CostFrom / Min(CostFrom, CostTo));
   end else
     Result := 1;

--- a/src/res/KM_ResWares.pas
+++ b/src/res/KM_ResWares.pas
@@ -56,6 +56,8 @@ const
   WEAPON_MAX = wt_Arbalet;
   WARFARE_MAX = wt_Horse;
 
+  WARE_FOOD = [wt_Wine, wt_Bread, wt_Sausages, wt_Fish];
+
   WARFARE_IRON = [wt_MetalShield, wt_MetalArmor, wt_Sword, wt_Hallebard, wt_Arbalet];
 
   MARKET_TRADEOFF_FACTOR = 2.2; //X resources buys 1 resource of equal value


### PR DESCRIPTION
Fixes only rates from food to smth else (except food), one way only.
To prevent players from trading starting food in storehouse to other good to get fast weapons. Normally food should be used to feed, not to get fast weapons. With these rates we make it very unprofitable.

Also small graphic fix - remove superfluous colon in the rates info labels