### PR TITLE
Fixed objects placement via scripts

### DIFF
--- a/src/terrain/KM_Terrain.pas
+++ b/src/terrain/KM_Terrain.pas
@@ -580,6 +580,22 @@ begin
   //Apply change
   //UpdatePassability and UpdateWalkConnect are called in SetField so that we only use it in trees and other objects
   case aObject of
+    55..59: // Corn and grapes: Set FieldAge if there's field to let them grow
+              begin
+                Land[Y, X].Obj := aObject;
+                Result := True;
+                if TileIsWineField(KMPoint(X, Y)) then
+                case aObject of
+                  55: Land[Y,X].FieldAge := WINE_AGE_1;
+                  56: Land[Y,X].FieldAge := WINE_AGE_2;
+                  57: Land[Y,X].FieldAge := WINE_AGE_FULL - 1;
+                end;
+                if TileIsCornField(KMPoint(X, Y)) then
+                case aObject of
+                  58: Land[Y,X].FieldAge := CORN_AGE_2;
+                  59: Land[Y,X].FieldAge := CORN_AGE_FULL - 1;
+                end;
+              end;
     88..124,
     126..172: // Trees - 125 is mushroom
               begin

--- a/src/terrain/KM_Terrain.pas
+++ b/src/terrain/KM_Terrain.pas
@@ -76,6 +76,9 @@ type
 
       Fence: TFenceType; //Fences (ropes, planks, stones)
       FenceSide: Byte; //Bitfield whether the fences are enabled
+
+      OccupiedByWorker: Boolean;  //Becomes true when worker gets a task (woodcutter wants to plant tree, farmer decided to harvest grapes, etc) and false when task is done/cancelled, or worker died
+
     end;
 
     FallingTrees: TKMPointTagList;
@@ -281,6 +284,7 @@ begin
     TreeAge      := IfThen(ObjectIsChopableTree(KMPoint(K, I), caAgeFull), TREE_AGE_FULL, 0);
     Fence        := fncNone;
     FenceSide    := 0;
+    OccupiedByWorker := False;
   end;
 
   fFinder := TKMTerrainFinder.Create;
@@ -563,8 +567,8 @@ var
 begin
   //Will this change make a unit stuck?
   if ((Land[Y, X].IsUnit <> nil) and MapElem[aObject].AllBlocked)
-  //Is this object part of a wine/corn field?
-  or TileIsWineField(KMPoint(X, Y)) or TileIsCornField(KMPoint(X, Y))
+  //Is this tile occupied by any worker (woodcutter wants to plant tree here, farmer decided to harvest grapes, etc)?
+  or Land[Y, X].OccupiedByWorker
   //Is there a house/site near this object?
   or HousesNearObject
   //Is this object allowed to be placed?

--- a/src/terrain/KM_Terrain.pas
+++ b/src/terrain/KM_Terrain.pas
@@ -580,22 +580,6 @@ begin
   //Apply change
   //UpdatePassability and UpdateWalkConnect are called in SetField so that we only use it in trees and other objects
   case aObject of
-    55..58:   // Wine in different stages
-              // Mapmaker still can use grapes as decoration
-              begin
-                Land[Y, X].Obj := aObject;
-                // No need to force adding winefield like this. Mapmaker can use Actions.GiveWinefield instead if needed
-                //SetField(KMPoint(X, Y), -1, ft_Wine);
-                Result := True;
-              end;
-    59..63:   // Corn in different stages
-              // Mapmaker still can use corn as decoration
-              begin
-                Land[Y, X].Obj := aObject;
-                // No need to force adding field like this. Mapmaker can use Actions.GiveField instead if needed
-                //SetField(KMPoint(X, Y), -1, ft_Corn);
-                Result := True;
-              end;
     88..124,
     126..172: // Trees - 125 is mushroom
               begin

--- a/src/terrain/KM_Terrain.pas
+++ b/src/terrain/KM_Terrain.pas
@@ -550,13 +550,12 @@ function TKMTerrain.ScriptTryObjectSet(X, Y: Integer; aObject: Byte): Boolean;
       end;
   end;
 
-  // Function allows objects in the same manner like in KaM Editor - we do not want falling trees, hidden objects etc.
+  // We do not want falling trees
   function AllowableObject: Boolean;
   begin
-    // Hide invisible wall (61), falling trees
-    Result := (aObject <> 61)
-              and (MapElem[aObject].Anim.Count > 0) and (MapElem[aObject].Anim.Step[1] > 0)
-              and (MapElem[aObject].Stump = -1);
+    // Hide falling trees
+    // Invisible objects like 255 can be useful to clear specified tile (since delete object = place object 255)
+    Result := (MapElem[aObject].Stump = -1) or (aObject = 255);
   end;
 
 var
@@ -568,7 +567,7 @@ begin
   or TileIsWineField(KMPoint(X, Y)) or TileIsCornField(KMPoint(X, Y))
   //Is there a house/site near this object?
   or HousesNearObject
-  //Is this object allowed to be placed - like in KaM Editor?
+  //Is this object allowed to be placed?
   or not AllowableObject then
   begin
     Result := False;
@@ -582,23 +581,21 @@ begin
   //UpdatePassability and UpdateWalkConnect are called in SetField so that we only use it in trees and other objects
   case aObject of
     55..58:   // Wine in different stages
-              if CanAddField(X, Y, ft_Wine) and (TileIsCoal(X, Y) <= 0) then // TileGoodForField does not check for coal deposit and puts a field there, we do not want this
+              // Mapmaker still can use grapes as decoration
               begin
                 Land[Y, X].Obj := aObject;
-                SetField(KMPoint(X, Y), -1, ft_Wine);
+                // No need to force adding winefield like this. Mapmaker can use Actions.GiveWinefield instead if needed
+                //SetField(KMPoint(X, Y), -1, ft_Wine);
                 Result := True;
-              end
-              else
-                Result := False;
+              end;
     59..63:   // Corn in different stages
-              if CanAddField(X, Y, ft_Corn) and (TileIsCoal(X, Y) <= 0) then  // TileGoodForField does not check for coal deposit and puts a field there, we do not want this
+              // Mapmaker still can use corn as decoration
               begin
                 Land[Y, X].Obj := aObject;
-                SetField(KMPoint(X, Y), -1, ft_Corn);
+                // No need to force adding field like this. Mapmaker can use Actions.GiveField instead if needed
+                //SetField(KMPoint(X, Y), -1, ft_Corn);
                 Result := True;
-              end
-              else
-                Result := False;
+              end;
     88..124,
     126..172: // Trees - 125 is mushroom
               begin

--- a/src/units/KM_Units.pas
+++ b/src/units/KM_Units.pas
@@ -105,6 +105,8 @@ type
 
     HitPointsInvulnerable: Boolean;
 
+    LastTaskPosition: TKMPoint; //Place where last task assigned (woodcutter wants to plant tree here, farmer decided to harvest grapes from this winefield, etc)
+
     constructor Create(aID: Cardinal; aUnitType: TUnitType; aLoc: TKMPoint; aOwner: TKMHandIndex);
     constructor Load(LoadStream: TKMemoryStream); dynamic;
     procedure SyncLoad; virtual;
@@ -1050,6 +1052,7 @@ begin
   fHitPoints      := HitPointsMax;
   fHitPointCounter := 1;
   HitPointsInvulnerable := False;
+  LastTaskPosition := KMPoint(0, 0);
 
   SetActionLockedStay(10, ua_Walk); //Must be locked for this initial pause so animals don't get pushed
   gTerrain.UnitAdd(NextPosition,Self);
@@ -1983,6 +1986,13 @@ begin
   and not ((fUnitTask is TTaskGoEat) and TTaskGoEat(fUnitTask).Eating) then
     //Make unit hungry as long as they are not currently eating in the inn
     Dec(fCondition);
+
+  if (IsIdle or (IsDeadOrDying))
+  and (not KMSamePoint(LastTaskPosition, KMPoint(0, 0))) then
+  begin
+    gTerrain.Land[LastTaskPosition.Y, LastTaskPosition.X].OccupiedByWorker := False;
+    LastTaskPosition := KMPoint(0, 0);
+  end;
 
   //Unit killing could be postponed by few ticks, hence fCondition could be <0
   if fCondition <= 0 then

--- a/src/units/KM_Units_WorkPlan.pas
+++ b/src/units/KM_Units_WorkPlan.pas
@@ -185,9 +185,8 @@ begin
   //Convert taAny to either a Tree or a Spot
   if (aPlantAct in [taCut, taAny])
   and ((TreeList.Count > 8) //Always chop the tree if there are many
-       or (BestToPlant.Count + SecondBestToPlant.Count = 0)
-       or ((TreeList.Count > 0) and (KaMRandom < TreeList.Count / (TreeList.Count + (BestToPlant.Count + SecondBestToPlant.Count)/15)))
-      ) then
+  or (BestToPlant.Count + SecondBestToPlant.Count = 0)
+  or ((TreeList.Count > 0) and (KaMRandom < TreeList.Count / (TreeList.Count + (BestToPlant.Count + SecondBestToPlant.Count)/15)))) then
   begin
     PlantAct := taCut;
     Result := TreeList.GetRandom(Tree);
@@ -249,6 +248,8 @@ begin
                                       end;
                             taPlant:  begin //Planting uses DirN (0) of ua_Work
                                         WalkStyle(Tmp, ua_WalkTool,ua_Work,12,0,ua_Walk,gs_WoodCutterPlant);
+                                        aUnit.LastTaskPosition := KMPoint(Tmp.Loc.X, Tmp.Loc.Y);
+                                        gTerrain.Land[aUnit.LastTaskPosition.Y, aUnit.LastTaskPosition.X].OccupiedByWorker := True;
                                       end;
                             else      fIssued := False;
                           end;
@@ -332,8 +333,14 @@ begin
                             taCut:    begin
                                         ResourcePlan(wt_None,0,wt_None,0,wt_Corn);
                                         WalkStyle(Tmp, ua_WalkTool,ua_Work,6,0,ua_WalkBooty,gs_FarmerCorn);
+                                        aUnit.LastTaskPosition := KMPoint(Tmp.Loc.X, Tmp.Loc.Y);
+                                        gTerrain.Land[aUnit.LastTaskPosition.Y, aUnit.LastTaskPosition.X].OccupiedByWorker := True;
                                       end;
-                            taPlant:  WalkStyle(Tmp, ua_Walk,ua_Work1,10,0,ua_Walk,gs_FarmerSow);
+                            taPlant:  begin
+                                        WalkStyle(Tmp, ua_Walk,ua_Work1,10,0,ua_Walk,gs_FarmerSow);
+                                        aUnit.LastTaskPosition := KMPoint(Tmp.Loc.X, Tmp.Loc.Y);
+                                        gTerrain.Land[aUnit.LastTaskPosition.Y, aUnit.LastTaskPosition.X].OccupiedByWorker := True;
+                                      end
                             else      fIssued := False;
                           end;
                       end else
@@ -345,6 +352,8 @@ begin
                         begin
                           ResourcePlan(wt_None,0,wt_None,0,wt_Wine);
                           WalkStyle(KMPointDir(Tmp.Loc,dir_N), ua_WalkTool2,ua_Work2,5,0,ua_WalkBooty2,gs_FarmerWine); //The animation for picking grapes is only defined for facing north
+                          aUnit.LastTaskPosition := KMPoint(Tmp.Loc.X, Tmp.Loc.Y);
+                          gTerrain.Land[aUnit.LastTaskPosition.Y, aUnit.LastTaskPosition.X].OccupiedByWorker := True;
                           SubActAdd(ha_Work1,1);
                           SubActAdd(ha_Work2,11);
                           SubActAdd(ha_Work5,1);


### PR DESCRIPTION
+ Mapmakers can use object 255 to clear specified tiles.
+ No need to force placing corn/wine fields in manner like here ( SetField(KMPoint(X, Y), -1, ft_Wine); ). Mapmaker can use grapes/corn as decoration, then fields aren't needed. There's also Actions.GiveField scripts for this.