### PR TITLE
Switch between build/ratios/stats/menu pages by shortcut keys

### DIFF
--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -2661,10 +2661,20 @@ begin
       Selection_Select(SelectId);
 
     // Menu shortcuts
-  if Key = gResKeys[SC_MENU_BUILD].Key then Button_Main[tbBuild].Click;
-  if Key = gResKeys[SC_MENU_RATIO].Key then Button_Main[tbRatio].Click;
-  if Key = gResKeys[SC_MENU_STATS].Key then Button_Main[tbStats].Click;
-  if Key = gResKeys[SC_MENU_MENU].Key  then Button_Main[tbMenu].Click;
+  if Key = gResKeys[SC_MENU_BUILD].Key then
+    if Button_Main[tbBuild].Enabled then
+      SwitchPage(Button_Main[tbBuild]);
+
+  if Key = gResKeys[SC_MENU_RATIO].Key then
+    if Button_Main[tbRatio].Enabled then
+      SwitchPage(Button_Main[tbRatio]);
+
+  if Key = gResKeys[SC_MENU_STATS].Key then
+    if Button_Main[tbStats].Enabled then
+      SwitchPage(Button_Main[tbStats]);
+
+  if Key = gResKeys[SC_MENU_MENU].Key then
+    SwitchPage(Button_Main[tbMenu]);
 
   if (fUIMode in [umSP, umReplay]) or MULTIPLAYER_SPEEDUP then
   begin


### PR DESCRIPTION
So players can open, for example, build menu directly from stats menu (no need to click back->new menu), etc.