### PR TITLE
lazarus task bar detection fix for "window save pos/state" feature

### DIFF
--- a/src/KM_FormMain.pas
+++ b/src/KM_FormMain.pas
@@ -567,6 +567,8 @@ begin
       Position := poDesigned;
       ClientWidth  := fMain.Settings.WindowParams.Width;
       ClientHeight := fMain.Settings.WindowParams.Height;
+      Left := fMain.Settings.WindowParams.Left;
+      Top := fMain.Settings.WindowParams.Top;
       WindowState  := fMain.Settings.WindowParams.State;
     end;
   end;
@@ -590,7 +592,10 @@ function TFormMain.GetWindowParams: TKMWindowParamsRecord;
     begin
       AppData.cbSize := SizeOf(TAppBarData);
       // SHAppBarMessage will return False (0) when an error happens.
-      if SHAppBarMessage(ABM_GETTASKBARPOS, AppData) <> 0 then
+      if SHAppBarMessage(ABM_GETTASKBARPOS,
+        {$IFDEF FPC}@AppData{$ENDIF}
+        {$IFDEF WDC}AppData{$ENDIF}
+        ) <> 0 then
       begin
         Result := AppData.uEdge;
         aRect := AppData.rc;


### PR DESCRIPTION
it was compilation error there in Lazarus.
Left and Top positions setting also fix load window at proper position when compile by Lazarus.

Also Lazarus can not detect WM_EXITSIZEMOVE windows message, so there is a small bug about it. There is a workaround how to fix it: http://free-pascal-lazarus.989080.n3.nabble.com/Lazarus-WMEnterSizeMove-Messages-not-firing-td4044372.html