### PR TITLE
BugFix: it's possible to type in spec channel in lobby chat, when not in specs anymore

### DIFF
--- a/src/gui/pages_menu/KM_GUIMenuLobby.pas
+++ b/src/gui/pages_menu/KM_GUIMenuLobby.pas
@@ -1003,6 +1003,10 @@ begin
     //Starting location
     if (Sender = DropBox_LobbyLoc[I]) and DropBox_LobbyLoc[I].Enabled then
     begin
+      // We can still have cmSpectate chat mode if we were in specs. Reset to cmAll in this case
+      if (DropBox_LobbyLoc[I].GetSelectedTag <> LOC_SPECTATE) and (fChatMode = cmSpectators) then
+        ChatMenuSelect(-1);
+      
       fNetworking.SelectLoc(DropBox_LobbyLoc[I].GetSelectedTag, NetI);
       //Host with HostDoesSetup could have given us some location we don't know about
       //from a map/save we don't have, so make sure SelectGameKind is valid


### PR DESCRIPTION
When first come as spec, choose spec channel, left specs (select any loc or random), spec channel still active and u can type in it, but can not see anything.