### PR TITLE
Set default "center screen" position in the center of screen for new map, created in MapEd

### DIFF
--- a/src/KM_Game.pas
+++ b/src/KM_Game.pas
@@ -800,7 +800,10 @@ begin
   gHands.AddPlayers(MAX_HANDS); //Create MAX players
   gHands[0].HandType := hndHuman; //Make Player1 human by default
   for I := 0 to gHands.Count - 1 do
+  begin
     gHands[I].FogOfWar.RevealEverything;
+    gHands[I].CenterScreen := KMPoint(aSizeX div 2, aSizeY div 2);
+  end;
 
   gMySpectator := TKMSpectator.Create(0);
   gMySpectator.FOWIndex := PLAYER_NONE;


### PR DESCRIPTION
instead of default (0;0) point.

Usually ppl will change it to a proper place, but its very usefull to have "center screen" point just in the center in case of creating many times small maps for testing purposes/building practice/etc, so after creating new map in MapEd (where any map opened in the center by default, which looks reasonable) you do not need to set its "center screen" position manually, so you can see what you have created in map ed immidiately after map start.