### PR TITLE
In maps/saves lists added column with mission mode (fight/build)

### DIFF
--- a/src/KM_Saves.pas
+++ b/src/KM_Saves.pas
@@ -12,7 +12,8 @@ type
     smByDescriptionAsc, smByDescriptionDesc,
     smByTimeAsc, smByTimeDesc,
     smByDateAsc, smByDateDesc,
-    smByPlayerCountAsc, smByPlayerCountDesc);
+    smByPlayerCountAsc, smByPlayerCountDesc,
+    smByModeAsc, smByModeDesc);
 
   TKMSaveInfo = class;
   TSaveEvent = procedure (aSave: TKMSaveInfo) of object;
@@ -318,6 +319,8 @@ procedure TKMSavesCollection.DoSort;
       smByDateDesc:        Result := A.Info.SaveTimestamp < B.Info.SaveTimestamp;
       smByPlayerCountAsc:  Result := A.Info.PlayerCount < B.Info.PlayerCount;
       smByPlayerCountDesc: Result := A.Info.PlayerCount > B.Info.PlayerCount;
+      smByModeAsc:         Result := A.Info.MissionMode < B.Info.MissionMode;
+      smByModeDesc:        Result := A.Info.MissionMode > B.Info.MissionMode;
     end;
   end;
 var

--- a/src/gui/pages_menu/KM_GUIMenuLoad.pas
+++ b/src/gui/pages_menu/KM_GUIMenuLoad.pas
@@ -3,7 +3,7 @@ unit KM_GUIMenuLoad;
 interface
 uses
   Controls, Math, SysUtils,
-  KM_Utils, KM_Controls, KM_Saves, KM_InterfaceDefaults, KM_Minimap;
+  KM_Utils, KM_Controls, KM_Saves, KM_InterfaceDefaults, KM_Minimap, KM_Defaults;
 
 
 type
@@ -45,7 +45,7 @@ type
 
 implementation
 uses
-  KM_ResTexts, KM_GameApp, KM_RenderUI, KM_ResFonts;
+  KM_ResTexts, KM_GameApp, KM_RenderUI, KM_ResFonts, KM_Pics;
 
 
 { TKMGUIMenuLoad }
@@ -65,8 +65,8 @@ begin
 
     ColumnBox_Load := TKMColumnBox.Create(Panel_Load, 22, 86, 770, 485, fnt_Metal, bsMenu);
     ColumnBox_Load.Anchors := [anLeft,anTop,anBottom];
-    ColumnBox_Load.SetColumns(fnt_Outline, [gResTexts[TX_MENU_LOAD_FILE], gResTexts[TX_MENU_LOAD_DATE], gResTexts[TX_MENU_LOAD_DESCRIPTION]], [0, 250, 430]);
-    ColumnBox_Load.SearchColumn := 0;
+    ColumnBox_Load.SetColumns(fnt_Outline, ['', gResTexts[TX_MENU_LOAD_FILE], gResTexts[TX_MENU_LOAD_DATE], gResTexts[TX_MENU_LOAD_DESCRIPTION]], [0, 22, 250, 430]);
+    ColumnBox_Load.SearchColumn := 1;
     ColumnBox_Load.OnColumnClick := Load_Sort;
     ColumnBox_Load.OnChange := Load_ListClick;
     ColumnBox_Load.OnDoubleClick := LoadClick;
@@ -183,6 +183,7 @@ end;
 
 procedure TKMMenuLoad.Load_RefreshList(aJumpToSelected:Boolean);
 var I, PrevTop: Integer;
+    Row: TKMListRow;
 begin
   PrevTop := ColumnBox_Load.TopIndex;
   ColumnBox_Load.Clear;
@@ -190,9 +191,12 @@ begin
   fSaves.Lock;
   try
     for I := 0 to fSaves.Count - 1 do
-      ColumnBox_Load.AddItem(MakeListRow(
-                        [fSaves[i].FileName, fSaves[i].Info.GetSaveTimestamp, fSaves[I].Info.GetTitleWithTime],
-                        [$FFFFFFFF, $FFFFFFFF, $FFFFFFFF]));
+    begin
+      Row := MakeListRow(['', fSaves[i].FileName, fSaves[i].Info.GetSaveTimestamp, fSaves[I].Info.GetTitleWithTime],
+                         [$FFFFFFFF, $FFFFFFFF, $FFFFFFFF, $FFFFFFFF]);
+      Row.Cells[0].Pic := MakePic(rxGui, 657 + Byte(fSaves[I].Info.MissionMode = mm_Tactic));
+      ColumnBox_Load.AddItem(Row);
+    end;
 
     //IDs of saves could changed, so use CRC to check which one was selected
     for I := 0 to fSaves.Count - 1 do
@@ -222,18 +226,22 @@ end;
 procedure TKMMenuLoad.Load_Sort(aIndex: Integer);
 begin
   case ColumnBox_Load.SortIndex of
-    //Sorting by filename goes A..Z by default
     0:  if ColumnBox_Load.SortDirection = sdDown then
+          fSaves.Sort(smByModeDesc, Load_SortUpdate)
+        else
+          fSaves.Sort(smByModeAsc, Load_SortUpdate);
+    //Sorting by filename goes A..Z by default
+    1:  if ColumnBox_Load.SortDirection = sdDown then
           fSaves.Sort(smByFileNameDesc, Load_SortUpdate)
         else
           fSaves.Sort(smByFileNameAsc, Load_SortUpdate);
     //Sorting by description goes Old..New by default
-    1:  if ColumnBox_Load.SortDirection = sdDown then
+    2:  if ColumnBox_Load.SortDirection = sdDown then
           fSaves.Sort(smByDateDesc, Load_SortUpdate)
         else
           fSaves.Sort(smByDateAsc, Load_SortUpdate);
     //Sorting by description goes A..Z by default
-    2:  if ColumnBox_Load.SortDirection = sdDown then
+    3:  if ColumnBox_Load.SortDirection = sdDown then
           fSaves.Sort(smByDescriptionDesc, Load_SortUpdate)
         else
           fSaves.Sort(smByDescriptionAsc, Load_SortUpdate);

--- a/src/gui/pages_menu/KM_GUIMenuMapEditor.pas
+++ b/src/gui/pages_menu/KM_GUIMenuMapEditor.pas
@@ -62,7 +62,7 @@ type
 
 implementation
 uses
-  KM_ResTexts, KM_Game, KM_GameApp, KM_RenderUI, KM_ResFonts, KM_InterfaceMapEditor, KM_Defaults;
+  KM_ResTexts, KM_Game, KM_GameApp, KM_RenderUI, KM_ResFonts, KM_InterfaceMapEditor, KM_Defaults, KM_Pics;
 
 
 const
@@ -128,8 +128,8 @@ begin
       Radio_MapEd_MapType.OnChange := MapTypeChange;
       ColumnBox_MapEd := TKMColumnBox.Create(Panel_MapEdLoad, 0, 80, 440, 506, fnt_Metal,  bsMenu);
       ColumnBox_MapEd.Anchors := [anLeft, anTop, anBottom];
-      ColumnBox_MapEd.SetColumns(fnt_Outline, [gResTexts[TX_MENU_MAP_TITLE], '#', gResTexts[TX_MENU_MAP_SIZE]], [0, 310, 340]);
-      ColumnBox_MapEd.SearchColumn := 0;
+      ColumnBox_MapEd.SetColumns(fnt_Outline, ['', gResTexts[TX_MENU_MAP_TITLE], '#', gResTexts[TX_MENU_MAP_SIZE]], [0, 22, 310, 340]);
+      ColumnBox_MapEd.SearchColumn := 1;
       ColumnBox_MapEd.OnColumnClick := ColumnClick;
       ColumnBox_MapEd.OnChange := SelectMap;
       ColumnBox_MapEd.OnDoubleClick := StartClick;
@@ -327,6 +327,7 @@ procedure TKMMenuMapEditor.RefreshList(aJumpToSelected:Boolean);
 var
   I, PrevTop: Integer;
   Maps: TKMapsCollection;
+  R: TKMListRow;
 begin
   PrevTop := ColumnBox_MapEd.TopIndex;
   ColumnBox_MapEd.Clear;
@@ -344,13 +345,11 @@ begin
   try
     for I := 0 to Maps.Count - 1 do
     begin
-      ColumnBox_MapEd.AddItem(MakeListRow( [Maps[I].FileName,
-                                           IntToStr(Maps[I].LocCount),
-                                           Maps[I].SizeText],
-                                           //Colors
-                                           [Maps[I].GetLobbyColor,
-                                           Maps[I].GetLobbyColor,
-                                           Maps[I].GetLobbyColor], I));
+      R := MakeListRow(['', Maps[I].FileName, IntToStr(Maps[I].LocCount), Maps[I].SizeText],  //Texts
+                       [Maps[I].GetLobbyColor, Maps[I].GetLobbyColor, Maps[I].GetLobbyColor, Maps[I].GetLobbyColor], //Colors
+                       I);
+      R.Cells[0].Pic := MakePic(rxGui, 657 + Byte(fMaps[I].MissionMode = mm_Tactic));
+      ColumnBox_MapEd.AddItem(R);
 
       if (Maps[I].CRC = fLastMapCRC) then
         ColumnBox_MapEd.ItemIndex := I;
@@ -380,14 +379,18 @@ begin
   with ColumnBox_MapEd do
   case SortIndex of
     0:  if SortDirection = sdDown then
+          SM := smByModeDesc
+        else
+          SM := smByModeAsc;
+    1:  if SortDirection = sdDown then
           SM := smByNameDesc
         else
           SM := smByNameAsc;
-    1:  if SortDirection = sdDown then
+    2:  if SortDirection = sdDown then
           SM := smByPlayersDesc
         else
           SM := smByPlayersAsc;
-    2:  if SortDirection = sdDown then
+    3:  if SortDirection = sdDown then
           SM := smBySizeDesc
         else
           SM := smBySizeAsc;

--- a/src/gui/pages_menu/KM_GUIMenuReplays.pas
+++ b/src/gui/pages_menu/KM_GUIMenuReplays.pas
@@ -3,7 +3,7 @@ unit KM_GUIMenuReplays;
 interface
 uses
   SysUtils, Controls, Math,
-  KM_Utils, KM_Controls, KM_Saves, KM_InterfaceDefaults, KM_Minimap, KM_Pics;
+  KM_Utils, KM_Controls, KM_Saves, KM_InterfaceDefaults, KM_Minimap, KM_Pics, KM_Defaults;
 
 
 type
@@ -83,9 +83,9 @@ begin
   Radio_Replays_Type.OnChange := Replay_TypeChange;
 
   ColumnBox_Replays := TKMColumnBox.Create(Panel_Replays, 22, 150, 770, 425, fnt_Metal, bsMenu);
-  ColumnBox_Replays.SetColumns(fnt_Outline, [gResTexts[TX_MENU_LOAD_FILE], gResTexts[TX_MENU_LOAD_DATE], gResTexts[TX_MENU_LOAD_DESCRIPTION]], [0, 250, 430]);
+  ColumnBox_Replays.SetColumns(fnt_Outline, ['', gResTexts[TX_MENU_LOAD_FILE], gResTexts[TX_MENU_LOAD_DATE], gResTexts[TX_MENU_LOAD_DESCRIPTION]], [0, 22, 250, 430]);
   ColumnBox_Replays.Anchors := [anLeft,anTop,anBottom];
-  ColumnBox_Replays.SearchColumn := 0;
+  ColumnBox_Replays.SearchColumn := 1;
   ColumnBox_Replays.OnChange := Replays_ListClick;
   ColumnBox_Replays.OnColumnClick := Replays_Sort;
   ColumnBox_Replays.OnDoubleClick := Replays_Play;
@@ -236,8 +236,8 @@ end;
 
 
 procedure TKMMenuReplays.Replays_RefreshList(aJumpToSelected: Boolean);
-var
-  I, PrevTop: Integer;
+var I, PrevTop: Integer;
+    Row: TKMListRow;
 begin
   PrevTop := ColumnBox_Replays.TopIndex;
   ColumnBox_Replays.Clear;
@@ -245,9 +245,12 @@ begin
   fSaves.Lock;
   try
     for I := 0 to fSaves.Count - 1 do
-      ColumnBox_Replays.AddItem(MakeListRow(
-                           [fSaves[I].FileName, fSaves[i].Info.GetSaveTimestamp, fSaves[I].Info.GetTitleWithTime],
-                           [$FFFFFFFF, $FFFFFFFF, $FFFFFFFF]));
+    begin
+      Row := MakeListRow(['', fSaves[i].FileName, fSaves[i].Info.GetSaveTimestamp, fSaves[I].Info.GetTitleWithTime],
+                         [$FFFFFFFF, $FFFFFFFF, $FFFFFFFF, $FFFFFFFF]);
+      Row.Cells[0].Pic := MakePic(rxGui, 657 + Byte(fSaves[I].Info.MissionMode = mm_Tactic));
+      ColumnBox_Replays.AddItem(Row);
+    end;
 
     for I := 0 to fSaves.Count - 1 do
       if (fSaves[I].CRC = fLastSaveCRC) then
@@ -275,16 +278,20 @@ begin
   case ColumnBox_Replays.SortIndex of
     //Sorting by filename goes A..Z by default
     0:  if ColumnBox_Replays.SortDirection = sdDown then
+          fSaves.Sort(smByModeDesc, Replays_SortUpdate)
+        else
+          fSaves.Sort(smByModeAsc, Replays_SortUpdate);
+    1:  if ColumnBox_Replays.SortDirection = sdDown then
           fSaves.Sort(smByFileNameDesc, Replays_SortUpdate)
         else
           fSaves.Sort(smByFileNameAsc, Replays_SortUpdate);
     //Sorting by description goes Old..New by default
-    1:  if ColumnBox_Replays.SortDirection = sdDown then
+    2:  if ColumnBox_Replays.SortDirection = sdDown then
           fSaves.Sort(smByDateDesc, Replays_SortUpdate)
         else
           fSaves.Sort(smByDateAsc, Replays_SortUpdate);
     //Sorting by description goes A..Z by default
-    2:  if ColumnBox_Replays.SortDirection = sdDown then
+    3:  if ColumnBox_Replays.SortDirection = sdDown then
           fSaves.Sort(smByDescriptionDesc, Replays_SortUpdate)
         else
           fSaves.Sort(smByDescriptionAsc, Replays_SortUpdate);


### PR DESCRIPTION
Storage/barracks pics used to show the modes. 

here is an example how it looks like for MapEd:  https://puu.sh/sSm35/69813babbd.png

I do not know what to put in the header of this column. Now I just left it without any header (pretend its obvious, because of pics). In new SP game we put same pic as for building map. 

This PR may be will have conflicts with [PR166](https://github.com/Kromster80/kam_remake/pull/166) and some changes should be done in one of them to update sorting mechanism with one new column.