### PR TITLE
Minimap for MP games: show in replays menu and lobby, if possible

### DIFF
--- a/src/KM_Defaults.pas
+++ b/src/KM_Defaults.pas
@@ -218,6 +218,8 @@ const
   RETURN_TO_LOBBY_SAVE = 'paused';
   DOWNLOADED_LOBBY_SAVE = 'downloaded';
 
+  MP_MINIMAP_SAVE_EXT = 'smm';
+
 type
   TKMHandIndex = {type} ShortInt;
   TKMHandIndexArray = array of TKMHandIndex;

--- a/src/KM_Saves.pas
+++ b/src/KM_Saves.pas
@@ -150,10 +150,11 @@ end;
 
 function TKMSaveInfo.LoadMinimap(aMinimap: TKMMinimap): Boolean;
 var
-  LoadStream: TKMemoryStream;
+  LoadStream, LoadMnmStream: TKMemoryStream;
   DummyInfo: TKMGameInfo;
   DummyOptions: TKMGameOptions;
   IsMultiplayer: Boolean;
+  MinimapFilePath: String;
 begin
   Result := False;
   if not FileExists(fPath + fFileName + '.sav') then Exit;
@@ -171,6 +172,24 @@ begin
     begin
       aMinimap.LoadFromStream(LoadStream);
       Result := True;
+    end else begin
+      // Lets try to load Minimap for MP save
+      LoadMnmStream := TKMemoryStream.Create;
+      try
+        try
+          MinimapFilePath := fPath + fFileName + '.' + MP_MINIMAP_SAVE_EXT;
+          if FileExists(MinimapFilePath) then
+          begin
+            LoadMnmStream.LoadFromFile(MinimapFilePath); // try to load minimap from file
+            aMinimap.LoadFromStream(LoadMnmStream);
+            Result := True;
+          end;
+        except
+          // Ignore any errors, because MP minimap is optional
+        end;
+      finally
+        LoadMnmStream.Free;
+      end;
     end;
 
   finally

--- a/src/gui/pages_menu/KM_GUIMenuLobby.pas
+++ b/src/gui/pages_menu/KM_GUIMenuLobby.pas
@@ -1692,7 +1692,6 @@ begin
                 S := fNetworking.SaveInfo;
                 Label_LobbyMapName.Caption := aData; //Show save name on host (local is always "downloaded")
                 Memo_LobbyMapDesc.Text := S.Info.GetTitleWithTime + '|' + S.Info.GetSaveTimestamp;
-                MinimapView_Lobby.Hide;
                 if S.IsValid and S.LoadMinimap(fMinimap) then
                 begin
                   MinimapView_Lobby.SetMinimap(fMinimap);

--- a/src/gui/pages_menu/KM_GUIMenuLobby.pas
+++ b/src/gui/pages_menu/KM_GUIMenuLobby.pas
@@ -1692,6 +1692,12 @@ begin
                 S := fNetworking.SaveInfo;
                 Label_LobbyMapName.Caption := aData; //Show save name on host (local is always "downloaded")
                 Memo_LobbyMapDesc.Text := S.Info.GetTitleWithTime + '|' + S.Info.GetSaveTimestamp;
+                MinimapView_Lobby.Hide;
+                if S.IsValid and S.LoadMinimap(fMinimap) then
+                begin
+                  MinimapView_Lobby.SetMinimap(fMinimap);
+                  MinimapView_Lobby.Show;
+                end;
               end;
     ngk_Map:  begin
                 M := fNetworking.MapInfo;


### PR DESCRIPTION
There was limitation for MP games minimap, they were not saving in *.sav file, because:
1) minimaps for different players are different, so *.sav files from different players will differ too. But when using save file for MP game we must be sure, that *.sav files are the same for every player to avoid inconsistency. Its very actual for "back to lobby" feature.
2) on minimap one player can possibly see smth about another player, what is hidden in game (in case full reveal minimap or minimap from possible enemy).

But minimap is very nice feature and it would be better if could have it in MP games too. For example when someone want to play again from save, he want to know, which save is better. So player could compare it by minimap - its not easy, but it can show approximately how big is your city. And it looks much better!

So I partially solved this problem by saving MP games minimap in a separate file with *.smm extension (Save MiniMap). Then problem number 1) is solved automatically, because your save file is same like before. Problem number 2) is also solved, because you can get minimap only from game you played (unless you manually put the minimap file, that somebody send you by skype, this option we obviously ignore). So you can not see anything new on that minimap.

Minimap is loading only if it possible, its not obligatory to have it.

Works well with "back to lobby".

The only thing that is not easy to fix - show minimap for new player (who did not play this save and do not have *.smm file). I think we can leave for now.