### PR TITLE
Colored niknames in chat system messages

### DIFF
--- a/src/KM_Game.pas
+++ b/src/KM_Game.pas
@@ -732,7 +732,7 @@ begin
               end;
     gmMulti:  begin
                 fNetworking.PostLocalMessage(Format(gResTexts[TX_MULTIPLAYER_PLAYER_DEFEATED],
-                                                    [gHands[aPlayerIndex].OwnerName]), csSystem);
+                  [fNetworking.GetNetPlayerByHandIndex(aPlayerIndex).NiknameColoredU]), csSystem);
                 if aPlayerIndex = gMySpectator.HandIndex then
                 begin
                   gSoundPlayer.Play(sfxn_Defeat, 1, True); //Fade music
@@ -741,7 +741,7 @@ begin
                 end;
               end;
     gmMultiSpectate: fNetworking.PostLocalMessage(Format(gResTexts[TX_MULTIPLAYER_PLAYER_DEFEATED],
-                                                  [gHands[aPlayerIndex].OwnerName]), csSystem);
+                       [fNetworking.GetNetPlayerByHandIndex(aPlayerIndex).NiknameColoredU]), csSystem);
     //We have not thought of anything to display on players defeat in Replay
   end;
 end;

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -2216,7 +2216,7 @@ begin
   begin
     txt := gResTexts[TX_MULTIPLAYER_WAITING] + ' ';
     for I := Low(aPlayers) to High(aPlayers) do
-      txt := txt + UnicodeString(gGame.Networking.NetPlayers[aPlayers[I]].Nikname) + IfThen(I <> High(aPlayers), ', ');
+      txt := txt + gGame.Networking.NetPlayers[aPlayers[I]].NiknameU + IfThen(I <> High(aPlayers), ', ');
 
     Button_NetDropPlayers.Visible := IsHost;
 
@@ -2515,7 +2515,7 @@ begin
       end;
 
       if gGame.Networking.NetPlayers[NetI].IsHuman then
-        Label_AlliesPlayer[I].Caption := UnicodeString(gGame.Networking.NetPlayers[NetI].Nikname)
+        Label_AlliesPlayer[I].Caption := gGame.Networking.NetPlayers[NetI].NiknameU
       else
         Label_AlliesPlayer[I].Caption := gHands[gGame.Networking.NetPlayers[NetI].StartLocation-1].OwnerName;
 

--- a/src/gui/pages_game/KM_GUIGameChat.pas
+++ b/src/gui/pages_game/KM_GUIGameChat.pas
@@ -185,7 +185,7 @@ begin
               with gGame.Networking.NetPlayers[I] do
               begin
                 fChatWhisperRecipient := I;
-                UpdateButtonCaption(UnicodeString(Nikname), IfThen(FlagColorID <> 0, FlagColorToTextColor(FlagColor), 0));
+                UpdateButtonCaption(NiknameU, IfThen(FlagColorID <> 0, FlagColorToTextColor(FlagColor), 0));
               end;
             end;
           end;
@@ -226,7 +226,7 @@ begin
     n := gGame.Networking.NetPlayers[I];
 
     if n.IsHuman and n.Connected and not n.Dropped then
-      Menu_Chat.AddItem(UnicodeString(n.NiknameColored), n.IndexOnServer);
+      Menu_Chat.AddItem(n.NiknameColoredU, n.IndexOnServer);
   end;
 
   C := TKMControl(Sender);

--- a/src/gui/pages_menu/KM_GUIMenuLobby.pas
+++ b/src/gui/pages_menu/KM_GUIMenuLobby.pas
@@ -591,7 +591,7 @@ begin
           with fNetworking.NetPlayers[I] do
           begin
             fChatWhisperRecipient := IndexOnServer;
-            UpdateButtonCaption(UnicodeString(Nikname), IfThen(FlagColorID <> 0, FlagColorToTextColor(FlagColor), 0));
+            UpdateButtonCaption(NiknameU, IfThen(FlagColorID <> 0, FlagColorToTextColor(FlagColor), 0));
           end;
         end;
       end;
@@ -630,7 +630,7 @@ begin
     n := fNetworking.NetPlayers[I];
 
     if n.IsHuman and n.Connected and not n.Dropped then
-      Menu_Chat.AddItem(UnicodeString(n.NiknameColored), n.IndexOnServer);
+      Menu_Chat.AddItem(n.NiknameColoredU, n.IndexOnServer);
   end;
 
   C := TKMControl(Sender);

--- a/src/net/KM_NetPlayersList.pas
+++ b/src/net/KM_NetPlayersList.pas
@@ -22,6 +22,10 @@ type
     fPingPos: Byte;
     procedure SetLangCode(const aCode: AnsiString);
     function GetNiknameColored: AnsiString;
+    function GetNikname: AnsiString;
+    function GetNiknameColoredU: UnicodeString;
+    function GetNiknameU: UnicodeString;
+    function GetHandIndex: Integer;
   public
     PlayerNetType: TNetPlayerType; //Human, Computer, Closed
     StartLocation: Integer;  //Start location, 0 means random, -1 means spectate
@@ -44,13 +48,16 @@ type
     function IsSpectator: Boolean;
     function GetPlayerType: THandType;
     function SlotName: UnicodeString; //Player name if it's human or computer or closed
-    property Nikname: AnsiString read fNikname; //Human player nikname (ANSI-Latin)
+    property Nikname: AnsiString read GetNikname; //Human player nikname (ANSI-Latin)
     property NiknameColored: AnsiString read GetNiknameColored;
+    property NiknameU: UnicodeString read GetNiknameU;
+    property NiknameColoredU: UnicodeString read GetNiknameColoredU;
     property LangCode: AnsiString read fLangCode write SetLangCode;
     property IndexOnServer: Integer read fIndexOnServer;
     property SetIndexOnServer: Integer write fIndexOnServer;
     function FlagColor(aDefault: Cardinal = $FF000000): Cardinal;
     property FlagColorID: Integer read fFlagColorID write fFlagColorID;
+    property HandIndex: Integer read GetHandIndex;
 
     procedure Save(SaveStream: TKMemoryStream);
     procedure Load(LoadStream: TKMemoryStream);
@@ -128,7 +135,7 @@ type
 
 implementation
 uses
-  KM_ResTexts, KM_Utils;
+  KM_ResTexts, KM_Utils, KM_HandsCollection;
 
 
 { TKMNetPlayerInfo }
@@ -222,12 +229,21 @@ end;
 function TKMNetPlayerInfo.SlotName: UnicodeString;
 begin
   case PlayerNetType of
-    nptHuman:     Result := UnicodeString(Nikname);
+    nptHuman:     Result := NiknameU;
     nptComputer:  //In lobby AI players don't have numbers yet (they are added on mission start)
                   Result := gResTexts[TX_LOBBY_SLOT_AI_PLAYER];
     nptClosed:    Result := gResTexts[TX_LOBBY_SLOT_CLOSED];
     else          Result := NO_TEXT;
   end;
+end;
+
+
+function TKMNetPlayerInfo.GetNikname: AnsiString;
+begin
+  if IsHuman or (gHands = nil) or (HandIndex = -1) then
+    Result := fNikname
+  else
+    Result := gHands[HandIndex].OwnerName;
 end;
 
 
@@ -237,6 +253,27 @@ begin
     Result := WrapColorA(Nikname, FlagColorToTextColor(FlagColor))
   else
     Result := Nikname;
+end;
+
+
+function TKMNetPlayerInfo.GetNiknameU: UnicodeString;
+begin
+  Result := UnicodeString(GetNikname);
+end;
+
+
+function TKMNetPlayerInfo.GetNiknameColoredU: UnicodeString;
+begin
+  Result := UnicodeString(GetNiknameColored);
+end;
+
+
+function TKMNetPlayerInfo.GetHandIndex: Integer;
+begin
+  if StartLocation > 0 then
+    Result := StartLocation - 1
+  else
+    Result := -1;
 end;
 
 
@@ -1056,7 +1093,7 @@ begin
   Result := '';
   for I := 1 to fCount do
   begin
-    Result := Result + '   ' + IntToStr(I) + ': ' + UnicodeString(fNetPlayers[I].Nikname);
+    Result := Result + '   ' + IntToStr(I) + ': ' + fNetPlayers[I].NiknameU;
     if I < fCount then
       Result := Result + '|';
   end;

--- a/src/net/KM_Networking.pas
+++ b/src/net/KM_Networking.pas
@@ -252,6 +252,9 @@ type
     procedure UpdateState(aTick: cardinal);
     procedure UpdateStateIdle;
     procedure FPSMeasurement(aFPS: Cardinal);
+
+    function GetNetPlayerByHandIndex(aHandIndex: Integer): TKMNetPlayerInfo;
+    function GetNetPlayerIndex(aHandIndex: Integer): Integer;
   end;
 
 
@@ -442,7 +445,7 @@ begin
     //Make sure this player is properly disconnected from the server
     PacketSend(NET_ADDRESS_SERVER, mk_KickPlayer, ServerIndex);
     NetPlayers.DropPlayer(ServerIndex);
-    PostMessage(TX_NET_DROPPED, csLeave, UnicodeString(NetPlayers[aPlayers[I]].Nikname));
+    PostMessage(TX_NET_DROPPED, csLeave, NetPlayers[aPlayers[I]].NiknameColoredU);
   end;
   SendPlayerListAndRefreshPlayersSetup;
 
@@ -746,7 +749,7 @@ procedure TKMNetworking.KickPlayer(aPlayerIndex: Integer);
 begin
   Assert(IsHost, 'Only host is allowed to kick players out');
   //No need to play a sound, server will do that when it announces that player disconnected
-  PostMessage(TX_NET_KICKED, csNone, UnicodeString(fNetPlayers[aPlayerIndex].Nikname));
+  PostMessage(TX_NET_KICKED, csNone, fNetPlayers[aPlayerIndex].NiknameColoredU);
   PacketSend(NET_ADDRESS_SERVER, mk_KickPlayer, fNetPlayers[aPlayerIndex].IndexOnServer);
 end;
 
@@ -755,7 +758,7 @@ procedure TKMNetworking.BanPlayer(aPlayerIndex: Integer);
 begin
   Assert(IsHost, 'Only host is allowed to ban players');
   //No need to play a sound, server will do that when it announces that player disconnected
-  PostMessage(TX_NET_BANNED, csNone, UnicodeString(fNetPlayers[aPlayerIndex].Nikname));
+  PostMessage(TX_NET_BANNED, csNone, fNetPlayers[aPlayerIndex].NiknameColoredU);
   PacketSend(NET_ADDRESS_SERVER, mk_BanPlayer, fNetPlayers[aPlayerIndex].IndexOnServer);
 end;
 
@@ -1383,7 +1386,7 @@ begin
                   PacketSend(aSenderIndex, mk_ReconnectionAccepted); //Tell this client they are back in the game
                   PacketSend(NET_ADDRESS_OTHERS, mk_ClientReconnected, aSenderIndex); //Tell everyone to ask him to resync
                   PacketSend(aSenderIndex, mk_ResyncFromTick, Integer(fLastProcessedTick)); //Ask him to resync us
-                  PostMessage(TX_NET_HAS_RECONNECTED, csJoin, UnicodeString(tmpStringA));
+                  PostMessage(TX_NET_HAS_RECONNECTED, csJoin, fNetPlayers[PlayerIndex].NiknameColoredU);
                 end
                 else
                 begin
@@ -1543,8 +1546,8 @@ begin
                   if PlayerIndex = -1 then exit; //Has already disconnected or not from our room
                   if not fNetPlayers[PlayerIndex].Dropped then
                   begin
-                    PostMessage(TX_NET_LOST_CONNECTION, csLeave, UnicodeString(fNetPlayers[PlayerIndex].Nikname));
-                    if WRITE_RECONNECT_LOG then gLog.AddTime(UnicodeString(fNetPlayers[PlayerIndex].Nikname)+' lost connection');
+                    PostMessage(TX_NET_LOST_CONNECTION, csLeave, fNetPlayers[PlayerIndex].NiknameColoredU);
+                    if WRITE_RECONNECT_LOG then gLog.AddTime(fNetPlayers[PlayerIndex].NiknameU+' lost connection');
                   end;
                   if fNetGameState = lgs_Game then
                     fNetPlayers.DisconnectPlayer(tmpInteger)
@@ -1577,7 +1580,7 @@ begin
                     begin
                       fFileSenderManager.ClientDisconnected(aSenderIndex);
                       if fNetPlayers.ServerToLocal(aSenderIndex) = -1 then exit; //Has already disconnected
-                      PostMessage(TX_NET_HAS_QUIT, csLeave, UnicodeString(fNetPlayers[fNetPlayers.ServerToLocal(aSenderIndex)].Nikname));
+                      PostMessage(TX_NET_HAS_QUIT, csLeave, fNetPlayers[fNetPlayers.ServerToLocal(aSenderIndex)].NiknameColoredU);
                       if fNetGameState in [lgs_Loading, lgs_Game] then
                         fNetPlayers.DropPlayer(aSenderIndex)
                       else
@@ -1592,7 +1595,7 @@ begin
                     begin
                       PlayerIndex := fNetPlayers.ServerToLocal(aSenderIndex);
                       if PlayerIndex = -1 then exit; //Has already disconnected
-                      PostLocalMessage(Format(gResTexts[TX_MULTIPLAYER_HOST_DISCONNECTED], [fNetPlayers[PlayerIndex].Nikname]), csLeave);
+                      PostLocalMessage(Format(gResTexts[TX_MULTIPLAYER_HOST_DISCONNECTED], [fNetPlayers[PlayerIndex].NiknameColoredU]), csLeave);
                       if fNetGameState in [lgs_Loading, lgs_Game] then
                         fNetPlayers.DropPlayer(aSenderIndex)
                       else
@@ -1652,7 +1655,7 @@ begin
                   or ((fSelectGameKind = ngk_Save) and not SaveInfo.IsValid) then
                     SelectNoMap(''); //In case the previous host had the map and we don't
                   SendPlayerListAndRefreshPlayersSetup;
-                  PostMessage(TX_NET_HOSTING_RIGHTS, csSystem, UnicodeString(fMyNikname));
+                  PostMessage(TX_NET_HOSTING_RIGHTS, csSystem, fNetPlayers[fMyIndex].NiknameColoredU);
                   if WRITE_RECONNECT_LOG then gLog.AddTime('Hosting rights reassigned to us ('+UnicodeString(fMyNikname)+')');
                 end;
               end;
@@ -1885,7 +1888,7 @@ begin
                 PlayerIndex := fNetPlayers.ServerToLocal(aSenderIndex);
                 if Assigned(fOnResyncFromTick) and (PlayerIndex<>-1) then
                 begin
-                  if WRITE_RECONNECT_LOG then gLog.AddTime('Resyncing player ' + UnicodeString(fNetPlayers[PlayerIndex].Nikname));
+                  if WRITE_RECONNECT_LOG then gLog.AddTime('Resyncing player ' + fNetPlayers[PlayerIndex].NiknameU);
                   fOnResyncFromTick(PlayerIndex, Cardinal(tmpInteger));
                 end;
               end;
@@ -1923,12 +1926,12 @@ begin
                   fNetPlayers.VoteActive := True;
                   if fNetPlayers.FurtherVotesNeededForMajority <= 0 then
                   begin
-                    PostMessage(TX_NET_VOTE_PASSED, csSystem, UnicodeString(fNetPlayers[PlayerIndex].NiknameColored));
+                    PostMessage(TX_NET_VOTE_PASSED, csSystem, fNetPlayers[PlayerIndex].NiknameColoredU);
                     ReturnToLobbyVoteSucceeded;
                   end
                   else
                   begin
-                    PostMessage(TX_NET_VOTED, csSystem, UnicodeString(fNetPlayers[PlayerIndex].NiknameColored), IntToStr(fNetPlayers.FurtherVotesNeededForMajority));
+                    PostMessage(TX_NET_VOTED, csSystem, fNetPlayers[PlayerIndex].NiknameColoredU, IntToStr(fNetPlayers.FurtherVotesNeededForMajority));
                     SendPlayerListAndRefreshPlayersSetup;
                   end;
                 end;
@@ -1984,9 +1987,9 @@ begin
                 if PlayerIndex <> -1 then
                 begin
                   if NetPlayers[PlayerIndex].FlagColorID <> 0 then
-                    tmpStringW := UnicodeString(WrapColorA(NetPlayers[PlayerIndex].Nikname, FlagColorToTextColor(NetPlayers[PlayerIndex].FlagColor))) + tmpStringW
+                    tmpStringW := WrapColor(NetPlayers[PlayerIndex].NiknameU, FlagColorToTextColor(NetPlayers[PlayerIndex].FlagColor)) + tmpStringW
                   else
-                    tmpStringW := UnicodeString(NetPlayers[PlayerIndex].Nikname) + tmpStringW;
+                    tmpStringW := NetPlayers[PlayerIndex].NiknameU + tmpStringW;
 
                   PostLocalMessage(tmpStringW, ChatSound);
                 end;
@@ -2281,4 +2284,31 @@ begin
 end;
 
 
+//Get NetPlayer by hand index. If no NetPlayer found for specified aHandIndex, then nil returned
+function TKMNetworking.GetNetPlayerByHandIndex(aHandIndex: Integer): TKMNetPlayerInfo;
+var Index: Integer;
+begin
+  Index := GetNetPlayerIndex(aHandIndex);
+  if Index <> -1 then
+    Result := fNetPlayers[Index]
+  else
+    Result := nil;
+end;
+
+
+//Get NetPlayer index by hand index. If no NetPlayer found for specified aHandIndex, then -1 returned
+function TKMNetworking.GetNetPlayerIndex(aHandIndex: Integer): Integer;
+var I: Integer;
+begin
+  Result := -1;
+  for I := 1 to MAX_LOBBY_SLOTS do
+    if aHandIndex = fNetPlayers[I].StartLocation-1 then
+    begin
+     Result := I;
+     Exit;
+    end;
+end;
+
+
 end.
+


### PR DESCRIPTION
we had some of them - when creating back to lobby vote, for example.
Added to all other system messages.
Added NiknameU and NiknameColoredU properties to avoid mass casting to UnicodeString(**)