### PR TITLE
bugfix: ProcessAttackPositions should be done after MultiplayerRig

### DIFF
--- a/src/KM_MissionScript_Standard.pas
+++ b/src/KM_MissionScript_Standard.pas
@@ -30,6 +30,7 @@ type
     constructor Create(aMode: TMissionParsingMode); overload;
     constructor Create(aMode: TMissionParsingMode; aPlayersEnabled: TKMHandEnabledArray); overload;
     function LoadMission(const aFileName: string): Boolean; overload; override;
+    procedure PostLoadMission;
 
     property DefaultLocation: ShortInt read fDefaultLocation;
     procedure SaveDATFile(const aFileName: string);
@@ -115,11 +116,15 @@ begin
   if not TokenizeScript(FileText, 6, []) then
     Exit;
 
-  //Post-processing of ct_Attack_Position commands which must be done after mission has been loaded
-  ProcessAttackPositions;
-
   //If we have reach here without exiting then loading was successful if no errors were reported
   Result := (fFatalErrors = '');
+end;
+
+
+procedure TMissionParserStandard.PostLoadMission;
+begin
+  //Post-processing of ct_Attack_Position commands which must be done after mission has been loaded
+  ProcessAttackPositions;
 end;
 
 


### PR DESCRIPTION
When in mission attack position set to house/unit, then if in MP game this house unit is an ally it is still could be attacked. This is because ProcessAttackPositions should be done after MultiplayerRig, where Hands info are setted (teams/allies etc).

Diff is a bit crazy about tabbing paragraphs (in TKMGame.GameStart). So actual changes there are:
added:
//some late operations for parser (f.e. ProcessAttackPositions, which should be done after MultiplayerRig)
    Parser.PostLoadMission;
to let Parser "live" (not freed) I put all the code between old Parser.Free and MultiplayerRig inside try finally block.
