### PR TITLE
MP chat focus improvement.

### DIFF
--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -2384,6 +2384,9 @@ begin
 
   //We want these keys to be ignored by chat, so game shortcuts still work
   if Key in [VK_F1..VK_F12, VK_ESCAPE] then Result := False;
+
+  //Ctrl can be used as an escape character, e.g. CTRL+B places beacon while chat is open
+  if ssCtrl in Shift then Result := (Key in [Ord('C'), Ord('X'), Ord('V')]);
 end;
 
 
@@ -2736,6 +2739,10 @@ begin
 
   //We want these keys to be ignored by chat, so game shortcuts still work
   if Key in [VK_F1..VK_F12, VK_ESCAPE] then Result := False;
+
+  //Ctrl can be used as an escape character, e.g. CTRL+B places beacon while chat is open
+  if ssCtrl in Shift then
+    Result := (Key in [Ord('C'), Ord('X'), Ord('V')]);
 end;
 
 

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -2384,9 +2384,6 @@ begin
 
   //We want these keys to be ignored by chat, so game shortcuts still work
   if Key in [VK_F1..VK_F12, VK_ESCAPE] then Result := False;
-
-  //Ctrl can be used as an escape character, e.g. CTRL+B places beacon while chat is open
-  if ssCtrl in Shift then Result := (Key in [Ord('C'), Ord('X'), Ord('V')]);
 end;
 
 
@@ -2739,10 +2736,6 @@ begin
 
   //We want these keys to be ignored by chat, so game shortcuts still work
   if Key in [VK_F1..VK_F12, VK_ESCAPE] then Result := False;
-
-  //Ctrl can be used as an escape character, e.g. CTRL+B places beacon while chat is open
-  if ssCtrl in Shift then
-    Result := (Key in [Ord('C'), Ord('X'), Ord('V')]);
 end;
 
 

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -109,6 +109,7 @@ type
     procedure SetAbsTop(aValue: Integer);
     procedure SetTopF(aValue: Single);
     procedure SetLeftF(aValue: Single);
+    function GetControlRect: TKMRect;
   protected
     procedure SetLeft(aValue: Integer); virtual;
     procedure SetTop(aValue: Integer); virtual;
@@ -135,6 +136,7 @@ type
     property Top: Integer read GetTop write SetTop;
     property Width: Integer read GetWidth write SetWidth;
     property Height: Integer read GetHeight write SetHeight;
+    property Rect: TKMRect read GetControlRect;
     property Anchors: TKMAnchorsSet read fAnchors write SetAnchors;
     property Enabled: Boolean read fEnabled write SetEnabled;
     property Visible: Boolean read GetVisible write SetVisible;
@@ -1451,6 +1453,13 @@ begin
   //Assign actual FP value
   fLeft := aValue;
 end;
+
+
+function TKMControl.GetControlRect: TKMRect;
+begin
+  Result := KMRect(Left, Top, Left + Width, Top + Height);
+end;
+
 
 //Overriden in child classes
 procedure TKMControl.SetHeight(aValue: Integer);

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -2739,13 +2739,17 @@ begin
   end;
   if Key = gResKeys[SC_DELETE_MSG].Key then Button_MessageDelete.Click;
   if Key = gResKeys[SC_CHAT_MP].Key then            // Enter is the shortcut to bring up chat in multiplayer
-    if (fUIMode in [umMP, umSpectate]) and not fGuiGameChat.Visible then
+    if (fUIMode in [umMP, umSpectate]) then
     begin
-      Allies_Close(nil);
-      Message_Close(nil);
-      MessageLog_Close(nil);
-      Label_MPChatUnread.Caption := ''; // No unread messages
-      fGuiGameChat.Show;
+      if not fGuiGameChat.Visible then
+      begin
+        Allies_Close(nil);
+        Message_Close(nil);
+        MessageLog_Close(nil);
+        Label_MPChatUnread.Caption := ''; // No unread messages
+        fGuiGameChat.Show;
+      end else
+        fGuiGameChat.Focus;
     end;
 
     // Standard army shortcuts from KaM
@@ -3080,6 +3084,15 @@ begin
     end;
     Exit;
   end;
+
+  // Check if mouse was clicked insede MP chat panel
+  if not KMInRect(KMPoint(X,Y), fGuiGameChat.PanelChatRect) then
+  begin
+    // Unset chat focus, when mouse clicked outside MP chat panel
+    fMyControls.CtrlFocus := nil;
+    fGuiGameChat.Unfocus;
+  end else
+    fGuiGameChat.Focus; // Set focus to MP chat
 
   if fPlacingBeacon and (Button = mbRight) then
   begin

--- a/src/gui/pages_game/KM_GUIGameChat.pas
+++ b/src/gui/pages_game/KM_GUIGameChat.pas
@@ -5,7 +5,7 @@ uses
   {$IFDEF MSWindows} Windows, {$ENDIF}
   {$IFDEF Unix} LCLIntf, LCLType, {$ENDIF}
   Math, StrUtils, SysUtils,
-  KM_Controls, KM_Defaults, KM_InterfaceDefaults, KM_InterfaceGame, KM_Networking;
+  KM_Controls, KM_Defaults, KM_InterfaceDefaults, KM_InterfaceGame, KM_Networking, KM_Points;
 
 
 type
@@ -20,6 +20,7 @@ type
     procedure Chat_MenuClick(Sender: TObject);
     procedure Chat_MenuSelect(aItem: Integer);
     procedure Chat_MenuShow(Sender: TObject);
+    function GetPanelChatRect: TKMRect;
   protected
     Panel_Chat: TKMPanel; //For multiplayer: Send, reply, text area for typing, etc.
       Dragger_Chat: TKMDragger;
@@ -35,6 +36,9 @@ type
     procedure SetChatState(const aChatState: TChatState);
     function GetChatState: TChatState;
     procedure ChatMessage(const aData: UnicodeString);
+    procedure Unfocus;
+    procedure Focus;
+    property PanelChatRect: TKMRect read GetPanelChatRect;
 
     procedure Show;
     procedure Hide;
@@ -200,6 +204,12 @@ begin
 end;
 
 
+function TKMGUIGameChat.GetPanelChatRect: TKMRect;
+begin
+  Result := Panel_Chat.Rect;
+end;
+
+
 procedure TKMGUIGameChat.Chat_MenuShow(Sender: TObject);
 var
   C: TKMControl;
@@ -274,11 +284,25 @@ begin
 end;
 
 
+procedure TKMGUIGameChat.Unfocus;
+begin
+  Edit_ChatMsg.Focusable := False;
+end;
+
+
+procedure TKMGUIGameChat.Focus;
+begin
+  Edit_ChatMsg.Focusable := True;
+  gGame.GamePlayInterface.MyControls.CtrlFocus := Edit_ChatMsg;
+end;
+
+
 procedure TKMGUIGameChat.Show;
 begin
   if not Panel_Chat.Visible then
     gSoundPlayer.Play(sfxn_MPChatOpen);
 
+  Focus;
   Panel_Chat.Show;
 end;
 


### PR DESCRIPTION
Game chat should not be in focus all the time. It must be possible to unset focus from without closing it, so any keyboard input processed as hotkeys, not as input typing in chat. When focus is unset it is still possible to read chat and using hotkeys.
To set focus - use 'open chat' hotkey, press button in game or just click on opened chat panel.
To unset focus - click anywhere outside of chat panel.