### PR TITLE
Selectable text in edit and memo

### DIFF
--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -3874,16 +3874,8 @@ begin
       SetSelections(CursorPos, SelectionEnd)
     else if aPrevCursorPos = SelectionEnd then
       SetSelections(SelectionStart, CursorPos);
-  end else begin
-    if CursorPos > aPrevCursorPos then
-    begin
-      SelectionStart := aPrevCursorPos;
-      SelectionEnd := CursorPos;
-    end else begin
-      SelectionStart := CursorPos;
-      SelectionEnd := aPrevCursorPos;
-    end;
-  end;
+  end else
+    SetSelections(aPrevCursorPos, CursorPos);
 end;
 
 
@@ -6360,11 +6352,9 @@ end;
 procedure TKMMasterControl.MouseDown(X,Y: Integer; Shift: TShiftState; Button: TMouseButton);
 begin
   CtrlDown := HitControl(X,Y);
+  fCtrl.ControlMouseDown(CtrlDown, Shift);
   if CtrlDown <> nil then
-  begin
-    fCtrl.ControlMouseDown(CtrlDown, Shift);
     CtrlDown.MouseDown(X, Y, Shift, Button);
-  end;
 end;
 
 
@@ -6411,11 +6401,9 @@ begin
   else
     fCtrlDown := nil;
 
+  fCtrl.ControlMouseUp(CtrlUp, Shift); // Must be invoked before CtrlUp.MouseUp to avoid problems on game Exit
   if CtrlUp <> nil then
-  begin
-    fCtrl.ControlMouseUp(CtrlUp, Shift); // Must be invoked before CtrlUp.MouseUp to avoid problems on game Exit
     CtrlUp.MouseUp(X, Y, Shift, Button);
-  end;
 
   //Do not place any code here, we could have Exited in OnClick event
 end;

--- a/src/KM_Defaults.pas
+++ b/src/KM_Defaults.pas
@@ -660,6 +660,8 @@ const
   icOrange = $FF0099FF;
   icRed    = $FF0707FF;
 
+  icSteelBlue = $FFA56D53; // Selection color
+
 
 var
   ExeDir: UnicodeString;

--- a/src/KM_Utils.pas
+++ b/src/KM_Utils.pas
@@ -55,6 +55,8 @@ uses
   procedure KMSwapInt(var A,B:integer); overload;
   procedure KMSwapInt(var A,B:cardinal); overload;
 
+  function GetNoColorMarkupText(aText: UnicodeString): UnicodeString;
+
   function GetMultiplicator(aShift: TShiftState): Word;
 
 implementation
@@ -634,6 +636,33 @@ end;
 function KaMRandomS(Range_Both_Directions:single):single; overload;
 begin
   Result := KaMRandom(round(Range_Both_Directions*20000)+1)/10000-Range_Both_Directions;
+end;
+
+
+// Returnes text ignoring color markup [$FFFFFF][]
+function GetNoColorMarkupText(aText: UnicodeString): UnicodeString;
+var I, TmpColor: Integer;
+begin
+  Result := '';
+
+  if aText = '' then Exit;
+
+  I := 1;
+  while I <= Length(aText) do
+  begin
+    //Ignore color markups [$FFFFFF][]
+    if (aText[I]='[') and (I+1 <= Length(aText)) and (aText[I+1]=']') then
+      Inc(I) //Skip past this markup
+    else
+      if (aText[I]='[') and (I+8 <= Length(aText))
+      and (aText[I+1] = '$') and (aText[I+8]=']')
+      and TryStrToInt(Copy(aText, I+1, 7), TmpColor) then
+        Inc(I,8) //Skip past this markup
+      else
+        //Not markup so count width normally
+        Result := Result + aText[I];
+    Inc(I);
+  end;
 end;
 
 

--- a/src/res/KM_ResFonts.pas
+++ b/src/res/KM_ResFonts.pas
@@ -82,7 +82,7 @@ type
 
     function GetCharWidth(aChar: WideChar): Integer;
     function WordWrap(aText: UnicodeString; aMaxPxWidth: Integer; aForced: Boolean; aIndentAfterNL: Boolean): UnicodeString;
-    function CharsThatFit(const aText: UnicodeString; aMaxPxWidth: integer): integer;
+    function CharsThatFit(const aText: UnicodeString; aMaxPxWidth: Integer; aRound: Boolean = False): Integer;
     function GetTextSize(const aText: UnicodeString; aCountMarkup: Boolean = False): TKMPoint;
   end;
 
@@ -607,20 +607,25 @@ begin
 end;
 
 
-function TKMFontData.CharsThatFit(const aText: UnicodeString; aMaxPxWidth:integer):integer;
+function TKMFontData.CharsThatFit(const aText: UnicodeString; aMaxPxWidth: Integer; aRound: Boolean = False): Integer;
 var
-  I, dx: Integer;
+  I, dx, LastCharW: Integer;
 begin
   dx := 0;
   Result := Length(aText);
 
   for I := 1 to Length(aText) do
   begin
-    Inc(dx, GetCharWidth(aText[I]));
+    LastCharW := GetCharWidth(aText[I]);
+    Inc(dx, LastCharW);
 
     if (dx > aMaxPxWidth) then
     begin
-      Result := I - 1; //Previous character fits, this one does not
+      // If we want to get approximate result, then check if total width is closer to prev width or to current
+      if aRound and (dx - aMaxPxWidth < aMaxPxWidth - (dx-LastCharW)) then
+        Result := I
+      else
+        Result := I - 1; //Previous character fits, this one does not
       Exit;
     end;
   end;


### PR DESCRIPTION
By default text in all TKMEdit's and TKMMemo is selectable.
Added most of text editors selecting features.
In Memo added cursor for selection. Memo loses focus automatically when other controls are clicked