### PR TITLE
Bugfix - initial selection of Memo do not handle keys until mouseUp

### DIFF
--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -4042,8 +4042,12 @@ end;
 procedure TKMMemo.MouseDown(X,Y: Integer; Shift: TShiftState; Button: TMouseButton);
 var OldCursorPos: Integer;
 begin
-  Focusable := fSelectable and (fText <> ''); // Do not focus on empty Memo's
   inherited;
+
+  Focusable := fSelectable and (fText <> ''); // Do not focus on empty Memo's
+  // Update Focus now, because we need to focus on MouseDown, not on MouseUp as by default for all controls
+  MasterParent.fCollection.UpdateFocus(Self);
+
   OldCursorPos := CursorPos;
   CursorPos := GetCursorPosAt(X, Y);
 


### PR DESCRIPTION
by default all controls get focus on mouse up, not on mouse down, so when you mouse down, then drag mouse (get selection) and press f.e. Ctrl+C text is not copied to buffer, because Memo did not get focus yet