### PR TITLE
Replay/Spectator. Update screen position on DropBox List OnClick event, not only on DropBox OnChange event

### DIFF
--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -938,6 +938,7 @@ type
     function GetSelectedTag: Integer;
     property DefaultCaption: UnicodeString read fDefaultCaption write fDefaultCaption;
     property Item[aIndex: Integer]: UnicodeString read GetItem;
+    property List: TKMListBox read fList;
 
     procedure Paint; override;
   end;

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -1878,8 +1878,6 @@ begin
 
   if (Sender = Dropbox_ReplayFOW) then
   begin
-    gMySpectator.HandIndex := Dropbox_ReplayFOW.GetTag(Dropbox_ReplayFOW.ItemIndex);
-
     UpdateScreenPosition;
 
     if Checkbox_ReplayFOW.Checked then

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -138,7 +138,7 @@ type
     procedure UpdateDebugInfo;
     procedure HidePages;
     procedure HideOverlay(Sender: TObject);
-    procedure UpdateScreenPosition;
+    procedure Replay_UpdateSpectatingPlayerView(aUpdateScreenPosOnly: Boolean = False);
     procedure ListClick(Sender: TObject);
   protected
     Sidebar_Top: TKMImage;
@@ -1799,11 +1799,11 @@ end;
 
 procedure TKMGamePlayInterface.ListClick(Sender: TObject);
 begin
-  UpdateScreenPosition;
+  Replay_UpdateSpectatingPlayerView(True);
 end;
 
 
-procedure TKMGamePlayInterface.UpdateScreenPosition;
+procedure TKMGamePlayInterface.Replay_UpdateSpectatingPlayerView(aUpdateScreenPosOnly: Boolean = False);
 var LastSelectedObj: TObject;
 begin
   gMySpectator.HandIndex := Dropbox_ReplayFOW.GetTag(Dropbox_ReplayFOW.ItemIndex);
@@ -1828,6 +1828,16 @@ begin
       fViewport.Position := KMPointF(gHands[gMySpectator.HandIndex].CenterScreen); //By default set viewport position to hand CenterScreen
 
     gMySpectator.Selected := LastSelectedObj;  // Change selected object to last one for this hand or Reset it to nil
+  end;
+
+  if not aUpdateScreenPosOnly then
+  begin
+    if Checkbox_ReplayFOW.Checked then
+      gMySpectator.FOWIndex := gMySpectator.HandIndex
+    else
+      gMySpectator.FOWIndex := -1;
+    fMinimap.Update(False); // Force update right now so FOW doesn't appear to lag
+    gGame.OverlayUpdate; // Display the overlay seen by the selected player
   end;
 end;
 
@@ -1877,16 +1887,7 @@ begin
   end;
 
   if (Sender = Dropbox_ReplayFOW) then
-  begin
-    UpdateScreenPosition;
-
-    if Checkbox_ReplayFOW.Checked then
-      gMySpectator.FOWIndex := gMySpectator.HandIndex
-    else
-      gMySpectator.FOWIndex := -1;
-    fMinimap.Update(False); // Force update right now so FOW doesn't appear to lag
-    gGame.OverlayUpdate; // Display the overlay seen by the selected player
-  end;
+    Replay_UpdateSpectatingPlayerView;
 
   if (Sender = Checkbox_ReplayFOW) then
   begin

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -138,6 +138,8 @@ type
     procedure UpdateDebugInfo;
     procedure HidePages;
     procedure HideOverlay(Sender: TObject);
+    procedure UpdateScreenPosition;
+    procedure ListClick(Sender: TObject);
   protected
     Sidebar_Top: TKMImage;
     Sidebar_Middle: TKMImage;
@@ -991,6 +993,7 @@ begin
     Dropbox_ReplayFOW := TKMDropList.Create(Panel_ReplayFOW, 0, 19, 160, 20, fnt_Metal, '', bsGame, False, 0.5);
     Dropbox_ReplayFOW.Hint := gResTexts[TX_REPLAY_PLAYER_PERSPECTIVE];
     Dropbox_ReplayFOW.OnChange := ReplayClick;
+    Dropbox_ReplayFOW.List.OnClick := ListClick;
  end;
 
 
@@ -1794,11 +1797,45 @@ begin
 end;
 
 
+procedure TKMGamePlayInterface.ListClick(Sender: TObject);
+begin
+  UpdateScreenPosition;
+end;
+
+
+procedure TKMGamePlayInterface.UpdateScreenPosition;
+var LastSelectedObj: TObject;
+begin
+  gMySpectator.HandIndex := Dropbox_ReplayFOW.GetTag(Dropbox_ReplayFOW.ItemIndex);
+
+  // Set position of the screen to last selected object if there was one, otherwise set position to starting center screen
+  // Only if Ctrl was pressed while changing Dropbox_ReplayFOW selection
+  if GetKeyState(VK_CONTROL) < 0 then
+  begin
+    LastSelectedObj := gMySpectator.LastSpecSelectedObj;
+    if LastSelectedObj <> nil then
+    begin
+      // Center screen on last selected object for chosen hand
+      if LastSelectedObj is TKMUnit then begin
+        fViewport.Position := TKMUnit(LastSelectedObj).PositionF;
+      end else if LastSelectedObj is TKMHouse then
+        fViewport.Position := KMPointF(TKMHouse(LastSelectedObj).GetEntrance)
+      else if LastSelectedObj is TKMUnitGroup then
+        fViewport.Position := TKMUnitGroup(LastSelectedObj).FlagBearer.PositionF
+      else
+        Assert(False, 'Could not determine last selected object type');
+    end else
+      fViewport.Position := KMPointF(gHands[gMySpectator.HandIndex].CenterScreen); //By default set viewport position to hand CenterScreen
+
+    gMySpectator.Selected := LastSelectedObj;  // Change selected object to last one for this hand or Reset it to nil
+  end;
+end;
+
+
 procedure TKMGamePlayInterface.ReplayClick(Sender: TObject);
 var
   oldCenter: TKMPointF;
   oldZoom: Single;
-  LastSelectedObj: TObject;
 begin
   if (Sender = Button_ReplayRestart) then
   begin
@@ -1843,27 +1880,7 @@ begin
   begin
     gMySpectator.HandIndex := Dropbox_ReplayFOW.GetTag(Dropbox_ReplayFOW.ItemIndex);
 
-    // Set position of the screen to last selected object if there was one, otherwise set position to starting center screen
-    // Only if Ctrl was pressed while changing Dropbox_ReplayFOW selection
-    if GetKeyState(VK_CONTROL) < 0 then
-    begin
-      LastSelectedObj := gMySpectator.LastSpecSelectedObj;
-      if LastSelectedObj <> nil then
-      begin
-        // Center screen on last selected object for chosen hand
-        if LastSelectedObj is TKMUnit then begin
-          fViewport.Position := TKMUnit(LastSelectedObj).PositionF;
-        end else if LastSelectedObj is TKMHouse then
-          fViewport.Position := KMPointF(TKMHouse(LastSelectedObj).GetEntrance)
-        else if LastSelectedObj is TKMUnitGroup then
-          fViewport.Position := TKMUnitGroup(LastSelectedObj).FlagBearer.PositionF
-        else
-          Assert(False, 'Could not determine last selected object type');
-      end else
-        fViewport.Position := KMPointF(gHands[gMySpectator.HandIndex].CenterScreen); //By default set viewport position to hand CenterScreen
-
-      gMySpectator.Selected := LastSelectedObj;  // Change selected object to last one for this hand or Reset it to nil
-    end;
+    UpdateScreenPosition;
 
     if Checkbox_ReplayFOW.Checked then
       gMySpectator.FOWIndex := gMySpectator.HandIndex


### PR DESCRIPTION
So when you click onto already selected element screen position will be updated even if no OnChange event was triggered.