### PR TITLE
Bugfix: rare bug with map moving out of downloads

### DIFF
--- a/src/KM_MapEditor.pas
+++ b/src/KM_MapEditor.pas
@@ -136,6 +136,7 @@ begin
       end;
     end;
   until (FindNext(SearchRec) <> 0);
+  FindClose(SearchRec);
 end;
 
 


### PR DESCRIPTION
Initial bug description:
The crash happens when you have a downloaded map and a "regular" (not downloaded) map with the same name in the map folder. Say you created a map named "example" and you also downloaded a map from a friend called "example." The downloaded version will have the checksum characters tagged on, such as "example_5A789EA6." If you wish to make the version downloaded from your friend the only version of the map, "example," in your folder, you first have to delete your own map. After deleting the map, you can then move the downloaded version out of downloads. This will cause a crash.

In summary:

1) Make a map, give it a name and save it
2) Download a map in mutiplayer lobby with the same name as your own created map
3) Delete your map
4) Move downloaded map out of downloads.

I could add to this that actually bug was when 
1. local file was opened in MapEditor (or probably game started), then 
2. this map was deleted
3. another map tried to be save with the same name

Solution
Add missing FindClose after FindFirst on mission load.

So after loading mission file File handler was allocated to KaM process. Then this bug occures.

I also checked all other usages of FindFirst.

