### PR TITLE
Fix the position of nodes (red dots) in CampaignBuilder

### DIFF
--- a/Utils/Campaign builder/Unit1.pas
+++ b/Utils/Campaign builder/Unit1.pas
@@ -365,8 +365,6 @@ begin
     imgNodes[I].Top := Image1.Top + C.Maps[fSelectedMap].Nodes[I].Y - imgNodes[I].Height div 2;
     imgNodes[I].Left := EnsureRange(imgNodes[I].Left, Image1.Left, Image1.Left + 1024-imgNodes[I].Width);
     imgNodes[I].Top  := EnsureRange(imgNodes[I].Top, Image1.Top, Image1.Top + 768-imgNodes[I].Height);
-    //Nodes If the position is less than zero
-    //We are making it equal to zero
   end;
 
   shpBriefing.Top := Image1.Height - shpBriefing.Height;

--- a/Utils/Campaign builder/Unit1.pas
+++ b/Utils/Campaign builder/Unit1.pas
@@ -363,6 +363,12 @@ begin
     //Position node centers, so that if someone changes the nodes they still look correct
     imgNodes[I].Left := Image1.Left + C.Maps[fSelectedMap].Nodes[I].X - imgNodes[I].Width div 2;
     imgNodes[I].Top := Image1.Top + C.Maps[fSelectedMap].Nodes[I].Y - imgNodes[I].Height div 2;
+    //Nodes If the position is less than zero
+    //We are making it equal to zero
+    if imgNodes[I].Left < 0 then
+      imgNodes[I].Left := 0;
+    if imgNodes[I].Top < 0 then
+      imgNodes[I].Top := 0;
   end;
 
   shpBriefing.Top := Image1.Height - shpBriefing.Height;

--- a/Utils/Campaign builder/Unit1.pas
+++ b/Utils/Campaign builder/Unit1.pas
@@ -159,8 +159,8 @@ begin
     Img := TImage(Sender);
     Assert(Img <> nil);
 
-    Img.Left := EnsureRange(Img.Left + (X - PrevX), Image1.Left, Image1.Left + 1024);
-    Img.Top  := EnsureRange(Img.Top  + (Y - PrevY), Image1.Top, Image1.Top + 768);
+    Img.Left := EnsureRange(Img.Left + (X - PrevX), Image1.Left, Image1.Left + 1024-Img.Width);
+    Img.Top  := EnsureRange(Img.Top  + (Y - PrevY), Image1.Top, Image1.Top + 768-Img.Height);
 
     C.Maps[fSelectedMap].Flag.X := Img.Left - Image1.Left;
     C.Maps[fSelectedMap].Flag.Y := Img.Top  - Image1.Top;
@@ -191,8 +191,8 @@ begin
     Img := TImage(Sender);
     Assert(Img <> nil);
 
-    Img.Left := EnsureRange(Img.Left + (X - PrevX), Image1.Left, Image1.Left + 1024);
-    Img.Top  := EnsureRange(Img.Top  + (Y - PrevY), Image1.Top, Image1.Top + 768);
+    Img.Left := EnsureRange(Img.Left + (X - PrevX), Image1.Left, Image1.Left + 1024-Img.Width);
+    Img.Top  := EnsureRange(Img.Top  + (Y - PrevY), Image1.Top, Image1.Top + 768-Img.Height);
 
     C.Maps[fSelectedMap].Nodes[fSelectedNode].X := Img.Left + Img.Width div 2  - Image1.Left;
     C.Maps[fSelectedMap].Nodes[fSelectedNode].Y := Img.Top  + Img.Height div 2 - Image1.Top;

--- a/Utils/Campaign builder/Unit1.pas
+++ b/Utils/Campaign builder/Unit1.pas
@@ -363,12 +363,10 @@ begin
     //Position node centers, so that if someone changes the nodes they still look correct
     imgNodes[I].Left := Image1.Left + C.Maps[fSelectedMap].Nodes[I].X - imgNodes[I].Width div 2;
     imgNodes[I].Top := Image1.Top + C.Maps[fSelectedMap].Nodes[I].Y - imgNodes[I].Height div 2;
+    imgNodes[I].Left := EnsureRange(imgNodes[I].Left, Image1.Left, Image1.Left + 1024-imgNodes[I].Width);
+    imgNodes[I].Top  := EnsureRange(imgNodes[I].Top, Image1.Top, Image1.Top + 768-imgNodes[I].Height);
     //Nodes If the position is less than zero
     //We are making it equal to zero
-    if imgNodes[I].Left < 0 then
-      imgNodes[I].Left := 0;
-    if imgNodes[I].Top < 0 then
-      imgNodes[I].Top := 0;
   end;
 
   shpBriefing.Top := Image1.Height - shpBriefing.Height;


### PR DESCRIPTION
Small fix problem solver output Nodes off-screen when you create.