### PR TITLE
Bugfix: do not allow empty filename when move map out of downloads or MapsMP folder can be deleted

### DIFF
--- a/src/gui/pages_menu/KM_GUIMenuMapEditor.pas
+++ b/src/gui/pages_menu/KM_GUIMenuMapEditor.pas
@@ -589,6 +589,15 @@ procedure TKMMenuMapEditor.MoveEditChange(Sender: TObject);
 var
   SaveName: string;
 begin
+  // Do not allow empty file name
+  if Trim(Edit_MapMove.Text) = '' then
+  begin
+    CheckBox_MoveExists.Visible := False;
+    Label_MoveExists.Visible := False;
+    Button_MapMoveConfirm.Enabled := False;
+    Exit;
+  end;
+
   SaveName := TKMapsCollection.FullPath(Trim(Edit_MapMove.Text), '.dat', mfMP);
 
   if (Sender = Edit_MapMove) or (Sender = Button_MapMove) then


### PR DESCRIPTION
1. There is some map in MapsDL folder
2. User press Move out of downloads button when this map is selected
3. clears map name edit field
4. press Move btn
Result - game will probably crash (sometimes it did not crash, idk why) and, what is much more important, **MapsMP folder will be DELETED**.

Probably it happens because when we move map we first try to delete existing map from MapsDL in case of same name (and overwrite checkbox checked), but if its name is empty then we delete parent dir...

MapsMP folder can be easily deleted with this 'trick' in r6720

in `procedure TKMapsCollection.MoveMap` only added first line with check `if Trim(aName) = '' then Exit;`, and fixed method indent.