### PR TITLE
Bug fix - refresh maps dropbox on show

### DIFF
--- a/src/gui/pages_menu/KM_GUIMenuLobby.pas
+++ b/src/gui/pages_menu/KM_GUIMenuLobby.pas
@@ -740,6 +740,7 @@ begin
   ChatMenuSelect(CHAT_MENU_ALL); //All
 
   Radio_LobbyMapType.ItemIndex := gGameApp.GameSettings.MenuLobbyMapType;
+  UpdateMapList;
 
   Panel_Lobby.Show;
   Lobby_Resize(aMainHeight);


### PR DESCRIPTION
needed because of Save option in Map type radio. When save is default option, then we need to update columnbox on menu page show, not only on radio OnChange event