### PR TITLE
Campaign mission title

### DIFF
--- a/src/KM_Campaigns.pas
+++ b/src/KM_Campaigns.pas
@@ -54,6 +54,7 @@ type
 
     function CampaignTitle: UnicodeString;
     function CampaignDescription: UnicodeString;
+    function CampaignMissionTitle : UnicodeString;
     function MissionFile(aIndex: Byte): UnicodeString;
     function MissionTitle(aIndex: Byte): UnicodeString;
     function MissionBriefing(aIndex: Byte): UnicodeString;
@@ -483,6 +484,12 @@ end;
 function TKMCampaign.CampaignDescription: UnicodeString;
 begin
   Result := fTextLib[2];
+end;
+
+
+function TKMCampaign.CampaignMissionTitle: UnicodeString;
+begin
+    Result := fTextLib[3];
 end;
 
 

--- a/src/gui/pages_menu/KM_GUIMenuCampaign.pas
+++ b/src/gui/pages_menu/KM_GUIMenuCampaign.pas
@@ -155,6 +155,7 @@ end;
 procedure TKMMenuCampaign.Campaign_SelectMap(Sender: TObject);
 var
   I: Integer;
+  sCampaignTitleMission : UnicodeString;
 begin
   if TKMControl(Sender).Tag > fCampaign.UnlockedMap then exit; //Skip closed maps
 
@@ -172,7 +173,11 @@ begin
     Image_CampaignSubNode[I].Top  := fCampaign.Maps[fMapIndex].Nodes[I].Y;
   end;
 
-  Label_CampaignTitle.Caption := Format(gResTexts[TX_GAME_MISSION], [fMapIndex+1]);
+  sCampaignTitleMission := fCampaign.CampaignMissionTitle;
+  if (Length(sCampaignTitleMission) > 3)and(Pos('%d', sCampaignTitleMission) > 0) then
+    Label_CampaignTitle.Caption := Format(sCampaignTitleMission, [fMapIndex+1])
+  else
+    Label_CampaignTitle.Caption := Format(gResTexts[TX_GAME_MISSION], [fMapIndex+1]);
   Label_CampaignText.Caption := fCampaign.MissionBriefing(fMapIndex);
 
   Panel_CampScroll.Left := IfThen(fCampaign.Maps[fMapIndex].TextPos = bcBottomRight, Panel_Campaign.Width - Panel_CampScroll.Width, 0);

--- a/src/gui/pages_menu/KM_GUIMenuCampaign.pas
+++ b/src/gui/pages_menu/KM_GUIMenuCampaign.pas
@@ -174,7 +174,7 @@ begin
   end;
 
   sCampaignTitleMission := fCampaign.CampaignMissionTitle;
-  if (Length(sCampaignTitleMission) > 3)and(Pos('%d', sCampaignTitleMission) > 0) then
+  if Pos('%d', AnsiLowerCase(sCampaignTitleMission)) > 0 then
     Label_CampaignTitle.Caption := Format(sCampaignTitleMission, [fMapIndex+1])
   else
     Label_CampaignTitle.Caption := Format(gResTexts[TX_GAME_MISSION], [fMapIndex+1]);


### PR DESCRIPTION
Add the ability to specify the title of the mission separately for each company rather than globally for all

Changes:
![image](https://cloud.githubusercontent.com/assets/17384156/22438243/0dd9d79c-e74d-11e6-98ad-06a86b5015d2.png)
![image](https://cloud.githubusercontent.com/assets/17384156/22438269/25cc434e-e74d-11e6-8198-2d8bc140352f.png)
![image](https://cloud.githubusercontent.com/assets/17384156/22438312/4240b55a-e74d-11e6-875c-46095af38772.png)
![image](https://cloud.githubusercontent.com/assets/17384156/22438324/4e91bb88-e74d-11e6-823a-82a83e8476e4.png)

If the title of missions to be found will be displayed in the campaign libx file it if not that of a standard file