### PR TITLE
Scripting overlay small visual fixes/refactoring

### DIFF
--- a/src/KM_Game.pas
+++ b/src/KM_Game.pas
@@ -113,6 +113,7 @@ type
     function IsMapEditor: Boolean;
     function IsMultiplayer: Boolean;
     function IsReplay: Boolean;
+    function IsSpeedUpAllowed: Boolean;
     function IsMPGameSpeedUpAllowed: Boolean;
     procedure ShowMessage(aKind: TKMMessageKind; aTextID: Integer; aLoc: TKMPoint; aHandIndex: TKMHandIndex);
     procedure ShowMessageLocal(aKind: TKMMessageKind; aText: UnicodeString; aLoc: TKMPoint);
@@ -977,6 +978,12 @@ begin
 end;
 
 
+function TKMGame.IsSpeedUpAllowed: Boolean;
+begin
+  Result := not IsMultiplayer or IsMPGameSpeedUpAllowed;
+end;
+
+
 function TKMGame.IsMPGameSpeedUpAllowed: Boolean;
 begin
   Result := (fGameMode in [gmMulti, gmMultiSpectate])
@@ -1192,7 +1199,7 @@ begin
   end;
 
   //don't show speed clock in MP since you can't turn it on/off
-  if (fGamePlayInterface <> nil) and (not IsMultiplayer or IsMPGameSpeedUpAllowed) then
+  if (fGamePlayInterface <> nil) and IsSpeedUpAllowed then
     fGamePlayInterface.ShowClock(fGameSpeed);
 
   //Need to adjust the delay immediately in MP

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -157,7 +157,6 @@ type
     Label_ClockSpeedup: TKMLabel;
 
     Label_ScriptedOverlay: TKMLabel; // Label that can be set from script
-    OverlayBackground: TKMBevel;
     Button_ScriptedOverlay: TKMButton;
     Label_OverlayShow, Label_OverlayHide: TKMLabel;
 
@@ -1012,10 +1011,6 @@ begin
 
 procedure TKMGamePlayInterface.Create_ScriptingOverlay;
 begin
-  OverlayBackground := TKMBevel.Create(Panel_Main, 255, 115, 1, 1);
-  OverlayBackground.Hitable := False;
-  OverlayBackground.Hide;
-
   Label_ScriptedOverlay := TKMLabel.Create(Panel_Main, 260, 110, '', fnt_Metal, taLeft);
 
   Button_ScriptedOverlay := TKMButton.Create(Panel_Main, 260, 92, 15, 15, '', bsGame);
@@ -2399,13 +2394,11 @@ begin
       OverlayTop := Max(OverlayTop, Image_Clock.Top + Image_Clock.Height + 25);
   end;
 
-  OverlayBackground.Top := OverlayTop + 17;
   Label_ScriptedOverlay.Top := OverlayTop + 19;
   Button_ScriptedOverlay.Top := OverlayTop + 1;
   Label_OverlayShow.Top := OverlayTop + 2;
   Label_OverlayHide.Top := OverlayTop;
 
-  OverlayBackground.Left := OverlayLeft;
   Label_ScriptedOverlay.Left := OverlayLeft + 5;
   Button_ScriptedOverlay.Left := OverlayLeft;
   Label_OverlayShow.Left := OverlayLeft + 3;
@@ -2414,10 +2407,6 @@ begin
   Button_ScriptedOverlay.Visible := Label_ScriptedOverlay.Caption <> '';
   Label_OverlayShow.Visible := (Label_ScriptedOverlay.Caption <> '') and not Label_ScriptedOverlay.Visible;
   Label_OverlayHide.Visible := (Label_ScriptedOverlay.Caption <> '') and Label_ScriptedOverlay.Visible;
-
-  OverlayBackground.Width := Label_ScriptedOverlay.TextSize.X + 10;
-  OverlayBackground.Height := Label_ScriptedOverlay.TextSize.Y + 3;
-  OverlayBackground.Visible := (Label_ScriptedOverlay.Caption <> '') and Label_ScriptedOverlay.Visible;
 end;
 
 

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -157,6 +157,7 @@ type
     Label_ClockSpeedup: TKMLabel;
 
     Label_ScriptedOverlay: TKMLabel; // Label that can be set from script
+    OverlayBackground: TKMBevel;
     Button_ScriptedOverlay: TKMButton;
     Label_OverlayShow, Label_OverlayHide: TKMLabel;
 
@@ -1011,7 +1012,11 @@ begin
 
 procedure TKMGamePlayInterface.Create_ScriptingOverlay;
 begin
-  Label_ScriptedOverlay := TKMLabel.Create(Panel_Main,260,110,'',fnt_Metal,taLeft);
+  OverlayBackground := TKMBevel.Create(Panel_Main, 255, 115, 1, 1);
+  OverlayBackground.Hitable := False;
+  OverlayBackground.Hide;
+
+  Label_ScriptedOverlay := TKMLabel.Create(Panel_Main, 260, 110, '', fnt_Metal, taLeft);
 
   Button_ScriptedOverlay := TKMButton.Create(Panel_Main, 260, 92, 15, 15, '', bsGame);
   Button_ScriptedOverlay.Hint := gResTexts[TX_GAMEPLAY_OVERLAY_HIDE];
@@ -2373,25 +2378,46 @@ begin
     Label_OverlayShow.Hide;
     Button_ScriptedOverlay.Hint := gResTexts[TX_GAMEPLAY_OVERLAY_HIDE];
   end;
+  UpdateOverlayControls;
 end;
 
 
 procedure TKMGamePlayInterface.UpdateOverlayControls;
-var OverlayTop: Integer;
+var OverlayTop, OverlayLeft: Integer;
 begin
-  OverlayTop := 8;
+  OverlayTop := 12;
+  OverlayLeft := 258;
 
   if Panel_ReplayFOW.Visible then
-    OverlayTop := Panel_ReplayFOW.Top + Panel_ReplayFOW.Height - 9;
+    OverlayTop := Panel_ReplayFOW.Top + Panel_ReplayFOW.Height - 5;
 
+  if gGame.IsSpeedUpAllowed then
+  begin
+    if not Panel_ReplayFOW.Visible then
+      OverlayLeft := Max(OverlayLeft, Image_Clock.Left + Image_Clock.Width + 10)
+    else
+      OverlayTop := Max(OverlayTop, Image_Clock.Top + Image_Clock.Height + 25);
+  end;
+
+  OverlayBackground.Top := OverlayTop + 17;
   Label_ScriptedOverlay.Top := OverlayTop + 19;
   Button_ScriptedOverlay.Top := OverlayTop + 1;
   Label_OverlayShow.Top := OverlayTop + 2;
   Label_OverlayHide.Top := OverlayTop;
 
+  OverlayBackground.Left := OverlayLeft;
+  Label_ScriptedOverlay.Left := OverlayLeft + 5;
+  Button_ScriptedOverlay.Left := OverlayLeft;
+  Label_OverlayShow.Left := OverlayLeft + 3;
+  Label_OverlayHide.Left := OverlayLeft + 3;
+
   Button_ScriptedOverlay.Visible := Label_ScriptedOverlay.Caption <> '';
-  Label_OverlayShow.Visible := (Label_ScriptedOverlay.Caption <> '') and not (Label_ScriptedOverlay.Visible);
-  Label_OverlayHide.Visible := (Label_ScriptedOverlay.Caption <> '') and (Label_ScriptedOverlay.Visible);
+  Label_OverlayShow.Visible := (Label_ScriptedOverlay.Caption <> '') and not Label_ScriptedOverlay.Visible;
+  Label_OverlayHide.Visible := (Label_ScriptedOverlay.Caption <> '') and Label_ScriptedOverlay.Visible;
+
+  OverlayBackground.Width := Label_ScriptedOverlay.TextSize.X + 10;
+  OverlayBackground.Height := Label_ScriptedOverlay.TextSize.Y + 3;
+  OverlayBackground.Visible := (Label_ScriptedOverlay.Caption <> '') and Label_ScriptedOverlay.Visible;
 end;
 
 

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -2387,12 +2387,7 @@ begin
     OverlayTop := Panel_ReplayFOW.Top + Panel_ReplayFOW.Height - 5;
 
   if gGame.IsSpeedUpAllowed then
-  begin
-    if not Panel_ReplayFOW.Visible then
-      OverlayLeft := Max(OverlayLeft, Image_Clock.Left + Image_Clock.Width + 10)
-    else
-      OverlayTop := Max(OverlayTop, Image_Clock.Top + Image_Clock.Height + 25);
-  end;
+    OverlayTop := Max(OverlayTop, Image_Clock.Top + Image_Clock.Height + 25);
 
   Label_ScriptedOverlay.Top := OverlayTop + 19;
   Button_ScriptedOverlay.Top := OverlayTop + 1;


### PR DESCRIPTION
- Fixed overlapping SpeedUp clock and overlay, when there was no ReplayFOW panel
- Added bevel for better text visibility. Bevel is not Hitable, so it ignores all mouse events


How it looks now:
1. No possible speed up clock and no ReplayFOW panel

![1](https://puu.sh/tIzEv/2b174dbfe4.png)

2. Possible speed up clock and no ReplayFOW panel. 'Possible' means this ScriptingOverlay positioning will be same, even if clock is invisible  (when speedup = x1). This is done to prevent unpleasant overlay 'jumping' left and right when game speed changes

![2](https://puu.sh/tIzO5/152d18a9c2.png)

3. Possible speed up clock and also ReplayFOW panel

![2](https://puu.sh/tIzXV/d58c839dff.png)

