### PR TITLE
Added ability to change log specification in F11 debug window

### DIFF
--- a/src/KM_Defaults.pas
+++ b/src/KM_Defaults.pas
@@ -83,7 +83,7 @@ var
   MODE_DESIGN_CONTORLS  :Boolean = False; //Special mode to move/edit controls activated by F7, it must block OnClick events! always Off here
   OVERLAY_RESOLUTIONS   :Boolean = False; //Render constraining frame
   LOCAL_SERVER_LIST     :Boolean = False; //Instead of loading server list from master server, add localhost:56789 (good for testing)
-  NET_SHOW_EACH_MSG     :Boolean = False; //Show each message kind arrived in chat (except ping/fps)
+  SHOW_LOGS_IN_CHAT     :Boolean = False; //Show log messages in MP game chat
   {Gameplay display}
   SKIP_RENDER           :Boolean = False; //Skip all the rendering in favor of faster logic
   SKIP_SOUND            :Boolean = False; //Skip all the sounds in favor of faster logic
@@ -132,9 +132,7 @@ var
   ALLOW_TAKE_AI_PLAYERS :Boolean = False; //Allow to load SP maps without Human player (usefull for AI testing)
   {Data output}
   WRITE_DECODED_MISSION :Boolean = False; //Save decoded mission as txt file
-  WRITE_DELIVERY_LOG    :Boolean = False; //Write even more output into log + slows down game noticably
   WRITE_WALKTO_LOG      :Boolean = False; //Write even more output into log + slows down game noticably
-  WRITE_RECONNECT_LOG   :Boolean = True;
   WriteResourceInfoToTXT:Boolean = False; //Whenever to write txt files with defines data properties on loading
   EXPORT_SPRITE_ATLASES :Boolean = False; //Whenever to write all generated textures to BMP on loading (extremely time consuming)
   EXPORT_INFLUENCE      :Boolean = False;

--- a/src/KM_FormMain.dfm
+++ b/src/KM_FormMain.dfm
@@ -3,7 +3,7 @@ object FormMain: TFormMain
   Top = 419
   HelpType = htKeyword
   BorderStyle = bsNone
-  ClientHeight = 532
+  ClientHeight = 656
   ClientWidth = 521
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
@@ -26,12 +26,12 @@ object FormMain: TFormMain
   OnShow = FormShow
   DesignSize = (
     521
-    532)
+    656)
   PixelsPerInch = 96
   TextHeight = 13
   object StatusBar1: TStatusBar
     Left = 0
-    Top = 512
+    Top = 636
     Width = 521
     Height = 20
     Panels = <
@@ -54,12 +54,13 @@ object FormMain: TFormMain
       item
         Width = 50
       end>
+    ExplicitTop = 680
   end
   object GroupBox1: TGroupBox
     Left = 320
     Top = 8
     Width = 193
-    Height = 489
+    Height = 624
     Anchors = [akTop, akRight]
     Caption = ' Development controls '
     TabOrder = 1
@@ -69,7 +70,7 @@ object FormMain: TFormMain
       Width = 177
       Height = 89
       Caption = ' Graphics tweaks '
-      TabOrder = 5
+      TabOrder = 4
       object Label3: TLabel
         Left = 100
         Top = 16
@@ -162,7 +163,7 @@ object FormMain: TFormMain
       Width = 177
       Height = 57
       Caption = ' User Interface '
-      TabOrder = 4
+      TabOrder = 3
       object chkUIControlsBounds: TCheckBox
         Left = 8
         Top = 16
@@ -208,7 +209,7 @@ object FormMain: TFormMain
         '6'
         '7'
         '8')
-      TabOrder = 1
+      TabOrder = 7
       OnClick = RGPlayerClick
     end
     object Button_Stop: TButton
@@ -217,7 +218,7 @@ object FormMain: TFormMain
       Width = 89
       Height = 17
       Caption = 'Stop the game'
-      TabOrder = 2
+      TabOrder = 1
       OnClick = Button_StopClick
     end
     object GroupBox2: TGroupBox
@@ -226,7 +227,7 @@ object FormMain: TFormMain
       Width = 177
       Height = 137
       Caption = ' AI '
-      TabOrder = 3
+      TabOrder = 2
       object Label5: TLabel
         Left = 108
         Top = 100
@@ -325,7 +326,7 @@ object FormMain: TFormMain
       Width = 177
       Height = 97
       Caption = ' Debug render '
-      TabOrder = 6
+      TabOrder = 5
       object Label2: TLabel
         Left = 100
         Top = 16
@@ -370,6 +371,58 @@ object FormMain: TFormMain
         Width = 121
         Height = 17
         Caption = 'Show selection buffer'
+        TabOrder = 3
+        OnClick = ControlsUpdate
+      end
+    end
+    object GroupBoxLogs: TGroupBox
+      Left = 8
+      Top = 481
+      Width = 177
+      Height = 138
+      Caption = 'Logs'
+      TabOrder = 6
+      object chkLogDelivery: TCheckBox
+        Left = 8
+        Top = 16
+        Width = 65
+        Height = 17
+        Caption = 'Delivery'
+        TabOrder = 0
+        OnClick = ControlsUpdate
+      end
+      object chkLogNetConnection: TCheckBox
+        Left = 79
+        Top = 16
+        Width = 95
+        Height = 17
+        Caption = 'Net connection'
+        Checked = True
+        State = cbChecked
+        TabOrder = 1
+        OnClick = ControlsUpdate
+      end
+      object RGLogNetPackets: TRadioGroup
+        Left = 8
+        Top = 36
+        Width = 161
+        Height = 78
+        Caption = 'Net packets log level'
+        ItemIndex = 0
+        Items.Strings = (
+          'None '
+          'All but commands/ping/fps'
+          'All but ping/fps'
+          'All packets')
+        TabOrder = 2
+        OnClick = ControlsUpdate
+      end
+      object chkLogsShowInChat: TCheckBox
+        Left = 8
+        Top = 116
+        Width = 137
+        Height = 17
+        Caption = 'Show logs in MP chat'
         TabOrder = 3
         OnClick = ControlsUpdate
       end

--- a/src/KM_FormMain.pas
+++ b/src/KM_FormMain.pas
@@ -78,6 +78,11 @@ type
     tbAngleZ: TTrackBar;
     Label7: TLabel;
     chkSelectionBuffer: TCheckBox;
+    GroupBoxLogs: TGroupBox;
+    chkLogDelivery: TCheckBox;
+    chkLogNetConnection: TCheckBox;
+    RGLogNetPackets: TRadioGroup;
+    chkLogsShowInChat: TCheckBox;
     procedure Export_TreeAnim1Click(Sender: TObject);
     procedure MenuItem1Click(Sender: TObject);
     procedure FormKeyUp(Sender: TObject; var Key: Word; Shift: TShiftState);
@@ -153,7 +158,8 @@ uses
   KM_ResSound,
   KM_Pics,
   KM_RenderPool,
-  KM_Hand;
+  KM_Hand,
+  KM_Log;
 
 
 //Remove VCL panel and use flicker-free TMyPanel instead
@@ -433,14 +439,17 @@ procedure TFormMain.ControlsReset;
     I: Integer;
   begin
     for I := 0 to aBox.ControlCount - 1 do
-    if aBox.Controls[I] is TCheckBox then
-      TCheckBox(aBox.Controls[I]).Checked := False
-    else
-    if aBox.Controls[I] is TTrackBar then
-      TTrackBar(aBox.Controls[I]).Position := 0
-    else
-    if aBox.Controls[I] is TGroupBox then
-      ResetGroupBox(TGroupBox(aBox.Controls[I]));
+      if aBox.Controls[I] is TCheckBox then
+        TCheckBox(aBox.Controls[I]).Checked := aBox.Controls[I] = chkLogNetConnection
+      else
+      if aBox.Controls[I] is TTrackBar then
+        TTrackBar(aBox.Controls[I]).Position := 0
+      else
+      if aBox.Controls[I] is TRadioGroup then
+        TRadioGroup(aBox.Controls[I]).ItemIndex := 0
+      else
+      if (aBox.Controls[I] is TGroupBox) then
+        ResetGroupBox(TGroupBox(aBox.Controls[I]));
   end;
 begin
   fUpdating := True;
@@ -538,6 +547,47 @@ begin
     end;
     HOUSE_BUILDING_STEP := tbBuildingStep.Position / tbBuildingStep.Max;
   end;
+
+  //Logs
+  SHOW_LOGS_IN_CHAT := chkLogsShowInChat.Checked;
+
+  if AllowDebugChange then
+  begin
+    if chkLogDelivery.Checked then
+      Include(gLog.MessageTypes, lmt_Delivery)
+    else
+      Exclude(gLog.MessageTypes, lmt_Delivery);
+
+    if chkLogNetConnection.Checked then
+      Include(gLog.MessageTypes, lmt_NetConnection)
+    else
+      Exclude(gLog.MessageTypes, lmt_NetConnection);
+
+    case RGLogNetPackets.ItemIndex of
+      0:    begin
+              Exclude(gLog.MessageTypes, lmt_NetPacketOther);
+              Exclude(gLog.MessageTypes, lmt_NetPacketCommand);
+              Exclude(gLog.MessageTypes, lmt_NetPacketPingFps);
+            end;
+      1:    begin
+              Include(gLog.MessageTypes, lmt_NetPacketOther);
+              Exclude(gLog.MessageTypes, lmt_NetPacketCommand);
+              Exclude(gLog.MessageTypes, lmt_NetPacketPingFps);
+            end;
+      2:    begin
+              Include(gLog.MessageTypes, lmt_NetPacketOther);
+              Include(gLog.MessageTypes, lmt_NetPacketCommand);
+              Exclude(gLog.MessageTypes, lmt_NetPacketPingFps);
+            end;
+      3:    begin
+              Include(gLog.MessageTypes, lmt_NetPacketOther);
+              Include(gLog.MessageTypes, lmt_NetPacketCommand);
+              Include(gLog.MessageTypes, lmt_NetPacketPingFps);
+            end;
+      else  raise Exception.Create('Unexpected RGLogNetPackets.ItemIndex = ' + IntToStr(RGLogNetPackets.ItemIndex));
+    end;
+  end;
+
 end;
 
 

--- a/src/KM_Game.pas
+++ b/src/KM_Game.pas
@@ -632,7 +632,7 @@ procedure TKMGame.GameMPDisconnect(const aData: UnicodeString);
 begin
   if fNetworking.NetGameState in [lgs_Game, lgs_Reconnecting] then
   begin
-    if WRITE_RECONNECT_LOG then gLog.AddTime('GameMPDisconnect: '+aData);
+    gLog.LogNetConnection('GameMPDisconnect: ' + aData);
     fNetworking.OnJoinFail := GameMPDisconnect; //If the connection fails (e.g. timeout) then try again
     fNetworking.OnJoinAssignedHost := nil;
     fNetworking.OnJoinSucc := nil;

--- a/src/KM_Log.pas
+++ b/src/KM_Log.pas
@@ -6,6 +6,11 @@ uses
 
 
 type
+
+  TKMLogMessageType = (lmt_Default, lmt_Delivery, lmt_NetConnection, lmt_NetPacketOther, lmt_NetPacketCommand, lmt_NetPacketPingFps);
+  TKMLogMessageTypeSet = set of TKMLogMessageType;
+  TNotifyEventLog = procedure(aLogMessage: UnicodeString) of object;
+
   //Logging system
   TKMLog = class
   private
@@ -14,9 +19,12 @@ type
     fFirstTick: cardinal;
     fPreviousTick: cardinal;
     fPreviousDate: TDateTime;
-    procedure AddLineTime(const aText: UnicodeString);
+    fOnLogMessage: TNotifyEventLog;
+    procedure AddLineTime(const aText: UnicodeString; aLogType: TKMLogMessageType); overload;
+    procedure AddLineTime(const aText: UnicodeString); overload;
     procedure AddLineNoTime(const aText: UnicodeString);
   public
+    MessageTypes: TKMLogMessageTypeSet;
     constructor Create(const aPath: UnicodeString);
     procedure InitLog;
     // AppendLog adds the line to Log along with time passed since previous line added
@@ -26,12 +34,18 @@ type
     procedure AddTime(num: Integer; const aText: UnicodeString); overload;
     procedure AddTime(const aText: UnicodeString; Res: boolean); overload;
     procedure AddTime(a, b: integer); overload;
+    procedure LogDelivery(const aText: UnicodeString);
+    procedure LogNetConnection(const aText: UnicodeString);
+    procedure LogNetPacketOther(const aText: UnicodeString);
+    procedure LogNetPacketCommand(const aText: UnicodeString);
+    procedure LogNetPacketPingFps(const aText: UnicodeString);
     // Add line if TestValue=false
     procedure AddAssert(const aMessageText: UnicodeString);
     // AddToLog simply adds the text
     procedure AddNoTime(const aText: UnicodeString);
     procedure DeleteOldLogs;
     property LogPath: UnicodeString read fLogPath; //Used by dedicated server
+    property OnLogMessage: TNotifyEventLog read fOnLogMessage write fOnLogMessage;
   end;
 
 var
@@ -41,6 +55,9 @@ var
 implementation
 uses
   KM_Defaults;
+
+const
+  DEFAULT_LOG_TYPES_TO_WRITE: TKMLogMessageTypeSet = [lmt_Default, lmt_NetConnection];
 
 
 //New thread, in which old logs are deleted (used internally)
@@ -92,6 +109,7 @@ begin
   fLogPath := aPath;
   fFirstTick := TimeGet;
   fPreviousTick := TimeGet;
+  MessageTypes := DEFAULT_LOG_TYPES_TO_WRITE;
   InitLog;
 end;
 
@@ -120,10 +138,11 @@ begin
 end;
 
 
-//Lines are timestamped, each line invokes file open/close for writing,
-//meaning that no lines will be lost if Remake crashes
-procedure TKMLog.AddLineTime(const aText: UnicodeString);
+procedure TKMLog.AddLineTime(const aText: UnicodeString; aLogType: TKMLogMessageType);
 begin
+  if not (aLogType in MessageTypes) then // write into log only for allowed types
+    Exit;
+
   if not FileExists(fLogPath) then
     InitLog;  // Recreate log file, if it was deleted
   AssignFile(fl, fLogPath);
@@ -143,6 +162,17 @@ begin
   CloseFile(fl);
   fPreviousTick := TimeGet;
   fPreviousDate := Now;
+
+  if Assigned(fOnLogMessage) then
+    fOnLogMessage(aText);
+end;
+
+
+//Lines are timestamped, each line invokes file open/close for writing,
+//meaning that no lines will be lost if Remake crashes
+procedure TKMLog.AddLineTime(const aText: UnicodeString);
+begin
+  AddLineTime(aText, lmt_Default);
 end;
 
 
@@ -155,6 +185,9 @@ begin
   Append(fl);
   WriteLn(fl, '                                      ' + aText);
   CloseFile(fl);
+
+  if Assigned(fOnLogMessage) then
+    fOnLogMessage(aText);
 end;
 
 
@@ -163,6 +196,46 @@ begin
   if Self = nil then Exit;
 
   AddLineTime(aText);
+end;
+
+
+procedure TKMLog.LogDelivery(const aText: UnicodeString);
+begin
+  if Self = nil then Exit;
+
+  AddLineTime(aText, lmt_Delivery);
+end;
+
+
+procedure TKMLog.LogNetConnection(const aText: UnicodeString);
+begin
+  if Self = nil then Exit;
+
+  AddLineTime(aText, lmt_NetConnection);
+end;
+
+
+procedure TKMLog.LogNetPacketOther(const aText: UnicodeString);
+begin
+  if Self = nil then Exit;
+
+  AddLineTime(aText, lmt_NetPacketOther);
+end;
+
+
+procedure TKMLog.LogNetPacketCommand(const aText: UnicodeString);
+begin
+  if Self = nil then Exit;
+
+  AddLineTime(aText, lmt_NetPacketCommand);
+end;
+
+
+procedure TKMLog.LogNetPacketPingFps(const aText: UnicodeString);
+begin
+  if Self = nil then Exit;
+
+  AddLineTime(aText, lmt_NetPacketPingFps);
 end;
 
 

--- a/src/KM_Log.pas
+++ b/src/KM_Log.pas
@@ -2,7 +2,7 @@ unit KM_Log;
 {$I KaM_Remake.inc}
 interface
 uses
-  SysUtils, Classes, KM_Utils;
+  SysUtils, Classes, KM_Utils, KM_CommonTypes;
 
 
 type
@@ -17,7 +17,6 @@ type
     lmt_NetPacketPingFps);  //log messages about ping/fps net packets
 
   TKMLogMessageTypeSet = set of TKMLogMessageType;
-  TNotifyEventLog = procedure(aLogMessage: UnicodeString) of object;
 
   //Logging system
   TKMLog = class
@@ -27,7 +26,7 @@ type
     fFirstTick: cardinal;
     fPreviousTick: cardinal;
     fPreviousDate: TDateTime;
-    fOnLogMessage: TNotifyEventLog;
+    fOnLogMessage: TUnicodeStringEvent;
     procedure AddLineTime(const aText: UnicodeString; aLogType: TKMLogMessageType); overload;
     procedure AddLineTime(const aText: UnicodeString); overload;
     procedure AddLineNoTime(const aText: UnicodeString);
@@ -53,7 +52,7 @@ type
     procedure AddNoTime(const aText: UnicodeString);
     procedure DeleteOldLogs;
     property LogPath: UnicodeString read fLogPath; //Used by dedicated server
-    property OnLogMessage: TNotifyEventLog read fOnLogMessage write fOnLogMessage;
+    property OnLogMessage: TUnicodeStringEvent read fOnLogMessage write fOnLogMessage;
   end;
 
 var

--- a/src/KM_Log.pas
+++ b/src/KM_Log.pas
@@ -7,7 +7,15 @@ uses
 
 type
 
-  TKMLogMessageType = (lmt_Default, lmt_Delivery, lmt_NetConnection, lmt_NetPacketOther, lmt_NetPacketCommand, lmt_NetPacketPingFps);
+  // Log message type
+  TKMLogMessageType = (
+    lmt_Default,            //default type
+    lmt_Delivery,           //delivery messages
+    lmt_NetConnection,      //messages about net connection/disconnection/reconnection
+    lmt_NetPacketOther,     //log messages about net packets (all packets, except GIP commands/ping/fps)
+    lmt_NetPacketCommand,   //log messages about GIP commands net packets
+    lmt_NetPacketPingFps);  //log messages about ping/fps net packets
+
   TKMLogMessageTypeSet = set of TKMLogMessageType;
   TNotifyEventLog = procedure(aLogMessage: UnicodeString) of object;
 
@@ -138,6 +146,8 @@ begin
 end;
 
 
+//Lines are timestamped, each line invokes file open/close for writing,
+//meaning that no lines will be lost if Remake crashes
 procedure TKMLog.AddLineTime(const aText: UnicodeString; aLogType: TKMLogMessageType);
 begin
   if not (aLogType in MessageTypes) then // write into log only for allowed types
@@ -168,15 +178,14 @@ begin
 end;
 
 
-//Lines are timestamped, each line invokes file open/close for writing,
-//meaning that no lines will be lost if Remake crashes
+//Add line with timestamp
 procedure TKMLog.AddLineTime(const aText: UnicodeString);
 begin
   AddLineTime(aText, lmt_Default);
 end;
 
 
-{Same line but without timestamp}
+//Same line but without timestamp
 procedure TKMLog.AddLineNoTime(const aText: UnicodeString);
 begin
   if not FileExists(fLogPath) then

--- a/src/KM_Utils.pas
+++ b/src/KM_Utils.pas
@@ -58,6 +58,8 @@ uses
 
   function GetNoColorMarkupText(aText: UnicodeString): UnicodeString;
 
+  function DeleteDoubleSpaces(aString: string): string;
+
   function GetMultiplicator(aShift: TShiftState): Word;
 
 implementation
@@ -670,6 +672,23 @@ begin
         //Not markup so count width normally
         Result := Result + aText[I];
     Inc(I);
+  end;
+end;
+
+
+//Replace continious spaces with single space
+function DeleteDoubleSpaces(aString: string): string;
+var I: Integer;
+begin
+  Result := '';
+  for I := 1 to Length(aString) do
+  begin
+    if aString[I] = ' ' then
+    begin
+      if not (aString[I-1] = ' ') then
+        Result := Result + ' ';
+    end else
+      Result := Result + aString[I];
   end;
 end;
 

--- a/src/KM_Utils.pas
+++ b/src/KM_Utils.pas
@@ -681,7 +681,10 @@ function DeleteDoubleSpaces(aString: string): string;
 var I: Integer;
 begin
   Result := '';
-  for I := 1 to Length(aString) do
+  if aString = '' then Exit;
+  Result := aString[1];
+
+  for I := 2 to Length(aString) do
   begin
     if aString[I] = ' ' then
     begin

--- a/src/hands/KM_HandLogistics.pas
+++ b/src/hands/KM_HandLogistics.pas
@@ -866,7 +866,7 @@ begin
   Inc(fOffer[iO].BeingPerformed); //Places a virtual "Reserved" sign on Offer
   Inc(fDemand[iD].BeingPerformed); //Places a virtual "Reserved" sign on Demand
 
-  if WRITE_DELIVERY_LOG then gLog.AddTime('Creating delivery ID', i);
+  gLog.LogDelivery('Creating delivery ID '+ IntToStr(i));
 
   //Now we have best job and can perform it
   if fDemand[iD].Loc_House <> nil then
@@ -880,7 +880,7 @@ end;
 procedure TKMDeliveries.TakenOffer(aID: Integer);
 var iO: Integer;
 begin
-  if WRITE_DELIVERY_LOG then gLog.AddTime('Taken offer from delivery ID', aID);
+  gLog.LogDelivery('Taken offer from delivery ID ' + IntToStr(aID));
 
   iO := fQueue[aID].OfferID;
   fQueue[aID].OfferID := 0; //We don't need it any more
@@ -900,7 +900,7 @@ end;
 procedure TKMDeliveries.GaveDemand(aID:integer);
 var iD:integer;
 begin
-  if WRITE_DELIVERY_LOG then gLog.AddTime('Gave demand from delivery ID', aID);
+  gLog.LogDelivery('Gave demand from delivery ID ' + IntToStr(aID));
   iD:=fQueue[aID].DemandID;
   fQueue[aID].DemandID:=0; //We don't need it any more
 
@@ -915,7 +915,7 @@ end;
 //AbandonDelivery
 procedure TKMDeliveries.AbandonDelivery(aID:integer);
 begin
-  if WRITE_DELIVERY_LOG then gLog.AddTime('Abandoned delivery ID', aID);
+  gLog.LogDelivery('Abandoned delivery ID ' + IntToStr(aID));
 
   //Remove reservations without removing items from lists
   if fQueue[aID].OfferID <> 0 then
@@ -940,7 +940,7 @@ end;
 //Job successfully done and we ommit it
 procedure TKMDeliveries.CloseDelivery(aID:integer);
 begin
-  if WRITE_DELIVERY_LOG then gLog.AddTime('Closed delivery ID', aID);
+  gLog.LogDelivery('Closed delivery ID ' + IntToStr(aID));
 
   fQueue[aID].OfferID:=0;
   fQueue[aID].DemandID:=0;

--- a/src/net/KM_Networking.pas
+++ b/src/net/KM_Networking.pas
@@ -143,6 +143,9 @@ type
 
     procedure ConnectSucceed(Sender:TObject);
     procedure ConnectFailed(const S: string);
+    function GetNetAddressPrintDescr(aNetworkAddress: Integer): String;
+    procedure LogPacket(aIsSending: Boolean; aKind: TKMessageKind; aNetworkAddress: Integer);
+    procedure PostLogMessageToChat(aLogMessage: UnicodeString);
     procedure PacketRecieve(aNetClient:TKMNetClient; aSenderIndex:integer; aData:pointer; aLength:cardinal); //Process all commands
     procedure PacketSend(aRecipient: Integer; aKind: TKMessageKind); overload;
     procedure PacketSend(aRecipient: Integer; aKind: TKMessageKind; aStream: TKMemoryStream); overload;
@@ -283,6 +286,7 @@ begin
   fMutedPlayersList := TList.Create;
   fFileSenderManager.OnTransferCompleted := TransferOnCompleted;
   fFileSenderManager.OnTransferPacket := TransferOnPacket;
+  gLog.OnLogMessage := PostLogMessageToChat;
   fVoteReturnToLobbySucceeded := False;
 end;
 
@@ -1161,7 +1165,7 @@ procedure TKMNetworking.DoReconnection;
 var
   TempMyIndex: Integer;
 begin
-  if WRITE_RECONNECT_LOG then gLog.AddTime(Format('DoReconnection: %s',[fMyNikname]));
+  gLog.LogNetConnection(Format('DoReconnection: %s',[fMyNikname]));
   fReconnectRequested := 0;
   PostLocalMessage(gResTexts[TX_NET_RECONNECTING], csSystem);
   //Stop the previous connection without calling Self.Disconnect as that frees everything
@@ -1244,6 +1248,55 @@ begin
 end;
 
 
+//Get printable name of network address
+function TKMNetworking.GetNetAddressPrintDescr(aNetworkAddress: Integer): String;
+  function GetNetPlayerDescr: String;
+  var NetPlayerIndex: Integer;
+  begin
+    NetPlayerIndex := fNetPlayers.ServerToLocal(aNetworkAddress);
+    if NetPlayerIndex = -1 then
+      Result := 'unknown'
+    else
+      Result := IntToStr(NetPlayerIndex);
+  end;
+begin
+  case aNetworkAddress of
+    NET_ADDRESS_EMPTY   : Result := 'EMPTY';
+    NET_ADDRESS_OTHERS  : Result := 'OTHERS';
+    NET_ADDRESS_ALL     : Result := 'ALL';
+    NET_ADDRESS_HOST    : Result := 'HOST';
+    NET_ADDRESS_SERVER  : Result := 'SERVER';
+    else                  Result := Format('Client %d [NetPlayer %s]', [aNetworkAddress, GetNetPlayerDescr]);
+  end;
+end;
+
+
+procedure TKMNetworking.LogPacket(aIsSending: Boolean; aKind: TKMessageKind; aNetworkAddress: Integer);
+var LogMessage: String;
+begin
+  if aIsSending then
+    LogMessage := 'Packet send:     %-23s to   %s'  // 23 is the length of mk_ command with the longest name
+  else
+    LogMessage := 'Packet recieved: %-23s from %s';
+
+  LogMessage := Format(LogMessage, [GetEnumName(TypeInfo(TKMessageKind), Integer(aKind)), GetNetAddressPrintDescr(aNetworkAddress)]);
+
+  case aKind of
+    mk_Ping, mk_Pong,
+    mk_PingInfo, mk_FPS:  gLog.LogNetPacketPingFps(LogMessage);
+    mk_Commands        :  gLog.LogNetPacketCommand(LogMessage);
+    else                  gLog.LogNetPacketOther(LogMessage);
+  end;
+end;
+
+
+procedure TKMNetworking.PostLogMessageToChat(aLogMessage: UnicodeString);
+begin
+  if SHOW_LOGS_IN_CHAT then
+    PostLocalMessage(DeleteDoubleSpaces(aLogMessage), csNone);
+end;
+
+
 procedure TKMNetworking.PacketRecieve(aNetClient: TKMNetClient; aSenderIndex: Integer; aData: Pointer; aLength: Cardinal);
 var
   M, M2: TKMemoryStream;
@@ -1282,8 +1335,7 @@ begin
       Exit;
     end;
 
-    if NET_SHOW_EACH_MSG and not (Kind in [mk_Ping, mk_PingInfo, mk_FPS]) then
-      PostLocalMessage(GetEnumName(TypeInfo(TKMessageKind), Integer(Kind)), csNone);
+    LogPacket(False, Kind, aSenderIndex);
 
     case Kind of
       mk_GameVersion:
@@ -1339,7 +1391,7 @@ begin
                 begin
                   if IsHost then
                   begin
-                    if WRITE_RECONNECT_LOG then gLog.AddTime('Hosting reconnection');
+                    gLog.LogNetConnection('Hosting reconnection');
                     //The other players must have been disconnected too, so we will be the host now
                     SetGameState(lgs_Game); //We are now in control of the game, so we are no longer reconnecting
                     //At this point we now know that every other client was dropped, but we probably missed the disconnect messages
@@ -1351,7 +1403,7 @@ begin
                   begin
                     PacketSendA(NET_ADDRESS_HOST, mk_AskToReconnect, fMyNikname);
                     fJoinTimeout := TimeGet; //Wait another X seconds for host to reply before timing out
-                    if WRITE_RECONNECT_LOG then gLog.AddTime('Asking to reconnect');
+                    gLog.LogNetConnection('Asking to reconnect');
                   end;
                 end
                 else
@@ -1387,7 +1439,7 @@ begin
                 tmpInteger := fNetPlayers.CheckCanReconnect(PlayerIndex);
                 if tmpInteger = -1 then
                 begin
-                  if WRITE_RECONNECT_LOG then gLog.AddTime(UnicodeString(tmpStringA) + ' successfully reconnected');
+                  gLog.LogNetConnection(UnicodeString(tmpStringA) + ' successfully reconnected');
                   fNetPlayers[PlayerIndex].SetIndexOnServer := aSenderIndex; //They will have a new index
                   fNetPlayers[PlayerIndex].Connected := True; //This player is now back online
                   SendPlayerListAndRefreshPlayersSetup;
@@ -1398,7 +1450,7 @@ begin
                 end
                 else
                 begin
-                  if WRITE_RECONNECT_LOG then gLog.AddTime(UnicodeString(tmpStringA) + ' asked to reconnect: ' + IntToStr(tmpInteger));
+                  gLog.LogNetConnection(UnicodeString(tmpStringA) + ' asked to reconnect: ' + IntToStr(tmpInteger));
                   PacketSend(aSenderIndex, mk_RefuseReconnect, tmpInteger);
                 end;
               end;
@@ -1555,7 +1607,7 @@ begin
                   if not fNetPlayers[PlayerIndex].Dropped then
                   begin
                     PostMessage(TX_NET_LOST_CONNECTION, csLeave, fNetPlayers[PlayerIndex].NiknameColoredU);
-                    if WRITE_RECONNECT_LOG then gLog.AddTime(fNetPlayers[PlayerIndex].NiknameU+' lost connection');
+                    gLog.LogNetConnection(fNetPlayers[PlayerIndex].NiknameU+' lost connection');
                   end;
                   if fNetGameState = lgs_Game then
                     fNetPlayers.DisconnectPlayer(tmpInteger)
@@ -1664,7 +1716,7 @@ begin
                     SelectNoMap(''); //In case the previous host had the map and we don't
                   SendPlayerListAndRefreshPlayersSetup;
                   PostMessage(TX_NET_HOSTING_RIGHTS, csSystem, fNetPlayers[fMyIndex].NiknameColoredU);
-                  if WRITE_RECONNECT_LOG then gLog.AddTime('Hosting rights reassigned to us ('+UnicodeString(fMyNikname)+')');
+                  gLog.LogNetConnection('Hosting rights reassigned to us ('+UnicodeString(fMyNikname)+')');
                 end;
               end;
 
@@ -1892,11 +1944,11 @@ begin
       mk_ResyncFromTick:
               begin
                 M.Read(tmpInteger);
-                if WRITE_RECONNECT_LOG then gLog.AddTime('Asked to resync from tick ' + IntToStr(tmpInteger));
+                gLog.LogNetConnection('Asked to resync from tick ' + IntToStr(tmpInteger));
                 PlayerIndex := fNetPlayers.ServerToLocal(aSenderIndex);
                 if Assigned(fOnResyncFromTick) and (PlayerIndex<>-1) then
                 begin
-                  if WRITE_RECONNECT_LOG then gLog.AddTime('Resyncing player ' + fNetPlayers[PlayerIndex].NiknameU);
+                  gLog.LogNetConnection('Resyncing player ' + fNetPlayers[PlayerIndex].NiknameU);
                   fOnResyncFromTick(PlayerIndex, Cardinal(tmpInteger));
                 end;
               end;
@@ -1904,7 +1956,7 @@ begin
       mk_ReconnectionAccepted:
               begin
                 //The host has accepted us back into the game!
-                if WRITE_RECONNECT_LOG then gLog.AddTime('Reconnection Accepted');
+                gLog.LogNetConnection('Reconnection Accepted');
                 SetGameState(lgs_Game); //Game is now running once again
                 fReconnectRequested := 0; //Cancel any retry in progress
                 //Request all other clients to resync us
@@ -1916,7 +1968,7 @@ begin
                 M.Read(tmpInteger);
                 //The host has accepted a disconnected client back into the game. Request this client to resync us
                 if tmpInteger = fMyIndexOnServer then exit;
-                if WRITE_RECONNECT_LOG then gLog.AddTime('Requesting resync for reconnected client');
+                gLog.LogNetConnection('Requesting resync for reconnected client');
                 PacketSend(tmpInteger, mk_ResyncFromTick, Integer(fLastProcessedTick));
               end;
 
@@ -2024,6 +2076,8 @@ var
 begin
   Assert(NetPacketType[aKind] = pfNoData);
 
+  LogPacket(True, aKind, aRecipient);
+
   M := TKMemoryStream.Create;
   M.Write(aKind, SizeOf(TKMessageKind));
 
@@ -2037,6 +2091,8 @@ var
   M: TKMemoryStream;
 begin
   Assert(NetPacketType[aKind] = pfBinary);
+
+  LogPacket(True, aKind, aRecipient);
 
   M := TKMemoryStream.Create;
   M.Write(aKind, SizeOf(TKMessageKind));
@@ -2055,6 +2111,8 @@ var
 begin
   Assert(NetPacketType[aKind] = pfNumber);
 
+  LogPacket(True, aKind, aRecipient);
+
   M := TKMemoryStream.Create;
   M.Write(aKind, SizeOf(TKMessageKind));
 
@@ -2071,6 +2129,8 @@ var
 begin
   Assert(NetPacketType[aKind] = pfStringA);
 
+  LogPacket(True, aKind, aRecipient);
+
   M := TKMemoryStream.Create;
   M.Write(aKind, SizeOf(TKMessageKind));
 
@@ -2086,6 +2146,8 @@ var
   M: TKMemoryStream;
 begin
   Assert(NetPacketType[aKind] = pfStringW);
+
+  LogPacket(True, aKind, aRecipient);
 
   M := TKMemoryStream.Create;
   M.Write(aKind, SizeOf(TKMessageKind));

--- a/src/net/KM_Networking.pas
+++ b/src/net/KM_Networking.pas
@@ -145,7 +145,7 @@ type
     procedure ConnectFailed(const S: string);
     function GetNetAddressPrintDescr(aNetworkAddress: Integer): String;
     procedure LogPacket(aIsSending: Boolean; aKind: TKMessageKind; aNetworkAddress: Integer);
-    procedure PostLogMessageToChat(aLogMessage: UnicodeString);
+    procedure PostLogMessageToChat(const aLogMessage: UnicodeString);
     procedure PacketRecieve(aNetClient:TKMNetClient; aSenderIndex:integer; aData:pointer; aLength:cardinal); //Process all commands
     procedure PacketSend(aRecipient: Integer; aKind: TKMessageKind); overload;
     procedure PacketSend(aRecipient: Integer; aKind: TKMessageKind; aStream: TKMemoryStream); overload;
@@ -1290,7 +1290,7 @@ begin
 end;
 
 
-procedure TKMNetworking.PostLogMessageToChat(aLogMessage: UnicodeString);
+procedure TKMNetworking.PostLogMessageToChat(const aLogMessage: UnicodeString);
 begin
   if SHOW_LOGS_IN_CHAT then
     PostLocalMessage(DeleteDoubleSpaces(aLogMessage), csNone);

--- a/src/units/KM_UnitTaskDelivery.pas
+++ b/src/units/KM_UnitTaskDelivery.pas
@@ -45,8 +45,7 @@ begin
 
   Assert((aFrom <> nil) and (toHouse <> nil) and (Res <> wt_None), 'Serf ' + IntToStr(fUnit.UID) + ': invalid delivery task');
 
-  if WRITE_DELIVERY_LOG then
-    gLog.AddTime('Serf ' + IntToStr(fUnit.UID) + ' created delivery task ' + IntToStr(fDeliverID));
+  gLog.LogDelivery('Serf ' + IntToStr(fUnit.UID) + ' created delivery task ' + IntToStr(fDeliverID));
 
   fFrom    := aFrom.GetHousePointer;
   fToHouse := toHouse.GetHousePointer;
@@ -68,7 +67,7 @@ begin
   fTaskName := utn_Deliver;
 
   Assert((aFrom<>nil) and (toUnit<>nil) and ((toUnit is TKMUnitWarrior) or (toUnit is TKMUnitWorker)) and (Res <> wt_None), 'Serf '+inttostr(fUnit.UID)+': invalid delivery task');
-  if WRITE_DELIVERY_LOG then gLog.AddTime('Serf '+inttostr(fUnit.UID)+' created delivery task '+inttostr(fDeliverID));
+  gLog.LogDelivery('Serf '+inttostr(fUnit.UID)+' created delivery task '+inttostr(fDeliverID));
 
   fFrom    := aFrom.GetHousePointer;
   fToUnit  := toUnit.GetUnitPointer;
@@ -101,7 +100,7 @@ end;
 
 destructor TTaskDeliver.Destroy;
 begin
-  if WRITE_DELIVERY_LOG then gLog.AddTime('Serf '+inttostr(fUnit.UID)+' abandoned delivery task '+inttostr(fDeliverID)+' at phase ' + inttostr(fPhase));
+  gLog.LogDelivery('Serf ' + IntToStr(fUnit.UID) + ' abandoned delivery task ' + IntToStr(fDeliverID) + ' at phase ' + IntToStr(fPhase));
 
   if fDeliverID <> 0 then
     gHands[fUnit.Owner].Deliveries.Queue.AbandonDelivery(fDeliverID);


### PR DESCRIPTION
Also added ability to post logs into MP chat.

Added new group box for F11 debug window. Here it is:

![Logs](https://puu.sh/tKh7j/2dcf832064.png)

- Delivery: turn On/Off delivery logs
- Net connection: turn On/Off network connection/reconnection/disconnection logs
- Net packets log level: radio group to define which net packets to log.
a. None: no packet will be logged
b. All but commands/ping/fps: all packets, except commands/ping/fps packets
c. All but ping/fps: all packets, except ping/fps packets
d. All packets
- Show logs in MP chat: all logs messages will be printed in chat, can be usefull sometimes, especially because we can copy into the buffer from chat window now. This feature replaces old global variable NET_SHOW_EACH_MSG. 

While in MP game if MULTIPLAYER_CHEATS var is set to False (by default for any release) then no network or delivery logs will be printed. This is made to avoid cheating because of possible log parsers.
