### PR TITLE
Bugfix: invalid woodcutters cutting point/barracks rally point

### DIFF
--- a/src/KM_BuildList.pas
+++ b/src/KM_BuildList.pas
@@ -254,7 +254,7 @@ begin
   for I := fHousesCount - 1 downto 0 do
   if (fHouses[i].House <> nil) and fHouses[i].House.CheckResToBuild
   and (fHouses[I].Assigned < MAX_WORKERS[fHouses[i].House.HouseType])
-  and aWorker.CanWalkTo(KMPointBelow(fHouses[i].House.GetEntrance), 0)
+  and aWorker.CanWalkTo(fHouses[i].House.PointBelowEntrance, 0)
   then
   begin
     NewBid := KMLengthDiag(aWorker.GetPosition, fHouses[I].House.GetPosition);
@@ -1295,7 +1295,7 @@ begin
       if (fHouseList.fHouses[i].House <> nil) and fHouseList.fHouses[i].House.CheckResToBuild
       and(fHouseList.fHouses[I].Assigned < MAX_WORKERS[fHouseList.fHouses[i].House.HouseType]) then
       begin
-        BestWorker := GetBestWorker(KMPointBelow(fHouseList.fHouses[I].House.GetEntrance));
+        BestWorker := GetBestWorker(fHouseList.fHouses[I].House.PointBelowEntrance);
         if BestWorker <> nil then fHouseList.GiveTask(I, BestWorker);
       end;
 end;
@@ -1325,7 +1325,7 @@ begin
       if (fRepairList.fHouses[i].House <> nil)
       and(fRepairList.fHouses[I].Assigned < MAX_WORKERS[fRepairList.fHouses[i].House.HouseType]) then
       begin
-        BestWorker := GetBestWorker(KMPointBelow(fRepairList.fHouses[I].House.GetEntrance));
+        BestWorker := GetBestWorker(fRepairList.fHouses[I].House.PointBelowEntrance);
         if BestWorker <> nil then fRepairList.GiveTask(I, BestWorker);
       end;
 end;

--- a/src/ai/KM_AIMayor.pas
+++ b/src/ai/KM_AIMayor.pas
@@ -395,12 +395,12 @@ begin
     //See if the road required is too long (tower might be across unwalkable terrain)
     H := P.Houses.FindHouse(ht_Any, BestLoc.X, BestLoc.Y, 1, False);
     if H = nil then Exit; //We are screwed, no houses left
-    LocTo := KMPointBelow(H.GetEntrance);
+    LocTo := H.PointBelowEntrance;
 
     //Find nearest complete house to get the road connect ID
     H := P.Houses.FindHouse(ht_Any, BestLoc.X, BestLoc.Y, 1, True);
     if H = nil then Exit; //We are screwed, no houses left
-    RoadConnectID := gTerrain.GetRoadConnectID(KMPointBelow(H.GetEntrance));
+    RoadConnectID := gTerrain.GetRoadConnectID(H.PointBelowEntrance);
 
     NodeList := TKMPointList.Create;
     RoadExists := fPathFindingRoad.Route_ReturnToWalkable(BestLoc, LocTo, RoadConnectID, NodeList);
@@ -438,12 +438,12 @@ begin
   //Find nearest wip or ready house
   H := P.Houses.FindHouse(ht_Any, aLoc.X, aLoc.Y, 1, False);
   if H = nil then Exit; //We are screwed, no houses left
-  LocTo := KMPointBelow(H.GetEntrance);
+  LocTo := H.PointBelowEntrance;
 
   //Find nearest complete house to get the road connect ID
   H := P.Houses.FindHouse(ht_Any, aLoc.X, aLoc.Y, 1, True);
   if H = nil then Exit; //We are screwed, no houses left
-  RoadConnectID := gTerrain.GetRoadConnectID(KMPointBelow(H.GetEntrance));
+  RoadConnectID := gTerrain.GetRoadConnectID(H.PointBelowEntrance);
 
   NodeList := TKMPointList.Create;
   try

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -672,7 +672,7 @@ begin
   if ((gMySpectator.Selected is TKMHouseBarracks) or (gMySpectator.Selected is TKMHouseWoodcutters)) and not fPlacingBeacon
   and (fUIMode in [umSP, umMP]) and not HasLostMPGame then
   begin
-    if gTerrain.Route_CanBeMade(KMPointBelow(TKMHouse(gMySpectator.Selected).GetEntrance), Loc, tpWalk, 0) then
+    if gTerrain.Route_CanBeMade(TKMHouse(gMySpectator.Selected).PointBelowEntrance, Loc, tpWalk, 0) then
     begin
       if gMySpectator.Selected is TKMHouseBarracks then
         gGame.GameInputProcess.CmdHouse(gic_HouseBarracksRally, TKMHouse(gMySpectator.Selected), Loc)
@@ -3395,7 +3395,7 @@ begin
         if ((gMySpectator.Selected is TKMHouseBarracks) or (gMySpectator.Selected is TKMHouseWoodcutters)) and not fPlacingBeacon
         and (fUIMode in [umSP, umMP]) and not HasLostMPGame then
         begin
-          if gTerrain.Route_CanBeMade(KMPointBelow(TKMHouse(gMySpectator.Selected).GetEntrance), P, tpWalk, 0) then
+          if gTerrain.Route_CanBeMade(TKMHouse(gMySpectator.Selected).PointBelowEntrance, P, tpWalk, 0) then
           begin
             if gMySpectator.Selected is TKMHouseBarracks then
               gGame.GameInputProcess.CmdHouse(gic_HouseBarracksRally, TKMHouse(gMySpectator.Selected), P)

--- a/src/hands/KM_Hand.pas
+++ b/src/hands/KM_Hand.pas
@@ -878,7 +878,7 @@ begin
   repeat
     //First make sure that it is valid
     if (H <> nil) and H.HasFood and H.HasSpace
-    and aUnit.CanWalkTo(Loc, KMPointBelow(H.GetEntrance), tpWalk, 0) then
+    and aUnit.CanWalkTo(Loc, H.PointBelowEntrance, tpWalk, 0) then
     begin
       //Take the closest inn out of the ones that are suitable
       Dist := KMLengthSqr(H.GetPosition, Loc);

--- a/src/hands/KM_HandLogistics.pas
+++ b/src/hands/KM_HandLogistics.pas
@@ -600,12 +600,12 @@ begin
   Result := Result and (
             ( //House-House delivery should be performed only if there's a connecting road
             (fDemand[iD].Loc_House <> nil) and
-            (gTerrain.Route_CanBeMade(KMPointBelow(fOffer[iO].Loc_House.GetEntrance), KMPointBelow(fDemand[iD].Loc_House.GetEntrance), tpWalkRoad, 0))
+            (gTerrain.Route_CanBeMade(fOffer[iO].Loc_House.PointBelowEntrance, fDemand[iD].Loc_House.PointBelowEntrance, tpWalkRoad, 0))
             )
             or
             ( //House-Unit delivery can be performed without connecting road
             (fDemand[iD].Loc_Unit <> nil) and
-            (gTerrain.Route_CanBeMade(KMPointBelow(fOffer[iO].Loc_House.GetEntrance), fDemand[iD].Loc_Unit.GetPosition, tpWalk, 1))
+            (gTerrain.Route_CanBeMade(fOffer[iO].Loc_House.PointBelowEntrance, fDemand[iD].Loc_Unit.GetPosition, tpWalk, 1))
             ));
 end;
 
@@ -616,7 +616,7 @@ var
   LocA, LocB: TKMPoint;
 begin
   LocA := aSerf.GetPosition;
-  LocB := KMPointBelow(fOffer[iO].Loc_House.GetEntrance);
+  LocB := fOffer[iO].Loc_House.PointBelowEntrance;
 
   //If the serf is inside the house (invisible) test from point below
   if not aSerf.Visible then

--- a/src/houses/KM_HouseBarracks.pas
+++ b/src/houses/KM_HouseBarracks.pas
@@ -53,7 +53,7 @@ begin
   inherited;
 
   fRecruitsList := TList.Create;
-  RallyPoint := KMPointBelow(GetEntrance);
+  RallyPoint := PointBelowEntrance;
 end;
 
 

--- a/src/houses/KM_HouseBarracks.pas
+++ b/src/houses/KM_HouseBarracks.pas
@@ -201,7 +201,7 @@ end;
 
 function TKMHouseBarracks.IsRallyPointSet: Boolean;
 begin
-   Result := not KMSamePoint(fRallyPoint, PointBelowEntrance);
+   Result := not KMSamePoint(RallyPoint, PointBelowEntrance); //Use RallyPoint, not fRallyPoint to be sure its Valid
 end;
 
 

--- a/src/houses/KM_HouseBarracks.pas
+++ b/src/houses/KM_HouseBarracks.pas
@@ -13,10 +13,11 @@ type
   private
     fRecruitsList: TList;
     fResourceCount: array [WARFARE_MIN..WARFARE_MAX] of Word;
+    fRallyPoint: TKMPoint;
+    function GetRallyPoint: TKMPoint;
   public
     MapEdRecruitCount: Word; //Only used by MapEd
     NotAcceptFlag: array [WARFARE_MIN .. WARFARE_MAX] of Boolean;
-    RallyPoint: TKMPoint;
     constructor Create(aUID: Integer; aHouseType: THouseType; PosX, PosY: Integer; aOwner: TKMHandIndex; aBuildState: THouseBuildState);
     constructor Load(LoadStream: TKMemoryStream); override;
     procedure Save(SaveStream: TKMemoryStream); override;
@@ -29,6 +30,8 @@ type
     procedure ResTakeFromOut(aWare: TWareType; aCount: Word = 1; aFromScript: Boolean = False); override;
     function CheckResIn(aWare: TWareType): Word; override;
     function ResCanAddToIn(aRes: TWareType): Boolean; override;
+
+    property RallyPoint: TKMPoint read GetRallyPoint write fRallyPoint;
 
     function ResOutputAvailable(aRes: TWareType; const aCount: Word): Boolean; override;
     function CanEquip(aUnitType: TUnitType): Boolean;
@@ -44,7 +47,7 @@ type
 
 implementation
 uses
-  KM_Units, KM_Units_Warrior, KM_HandsCollection, KM_ResUnits, KM_Hand;
+  KM_Units, KM_Units_Warrior, KM_HandsCollection, KM_ResUnits, KM_Hand, KM_Terrain;
 
 
 { TKMHouseBarracks }
@@ -53,7 +56,7 @@ begin
   inherited;
 
   fRecruitsList := TList.Create;
-  RallyPoint := PointBelowEntrance;
+  fRallyPoint := PointBelowEntrance;
 end;
 
 
@@ -73,7 +76,7 @@ begin
     fRecruitsList.Add(U);
   end;
   LoadStream.Read(NotAcceptFlag, SizeOf(NotAcceptFlag));
-  LoadStream.Read(RallyPoint);
+  LoadStream.Read(fRallyPoint);
 end;
 
 
@@ -198,7 +201,7 @@ end;
 
 function TKMHouseBarracks.IsRallyPointSet: Boolean;
 begin
-   Result := not KMSamePoint(RallyPoint, KMPointBelow(GetEntrance));
+   Result := not KMSamePoint(fRallyPoint, PointBelowEntrance);
 end;
 
 
@@ -274,6 +277,15 @@ begin
 end;
 
 
+function TKMHouseBarracks.GetRallyPoint: TKMPoint;
+begin
+  if not gTerrain.CheckPassability(fRallyPoint, tpWalk) then
+    //update rally point if its not valid (not walkable). Set it closer to barracks entrance (PointBelowEntrance)
+    fRallyPoint := gTerrain.GetPassablePointWithinSegment(PointBelowEntrance, fRallyPoint, tpWalk);
+  Result := fRallyPoint;
+end;
+
+
 procedure TKMHouseBarracks.Save(SaveStream: TKMemoryStream);
 var
   I: Integer;
@@ -285,7 +297,7 @@ begin
   for I := 0 to RecruitsCount - 1 do
     SaveStream.Write(TKMUnit(fRecruitsList.Items[I]).UID); //Store ID
   SaveStream.Write(NotAcceptFlag, SizeOf(NotAcceptFlag));
-  SaveStream.Write(RallyPoint);
+  SaveStream.Write(fRallyPoint);
 end;
 
 

--- a/src/houses/KM_HouseCollection.pas
+++ b/src/houses/KM_HouseCollection.pas
@@ -159,7 +159,7 @@ begin
     begin
       //Recruits should not go to a barracks with ware delivery switched off
       if (Houses[I].HouseType = ht_Barracks) and (not Houses[I].WareDelivery) then Continue;
-      if not gTerrain.Route_CanBeMade(Loc, KMPointBelow(Houses[I].GetEntrance), tpWalk, 0) then Continue;
+      if not gTerrain.Route_CanBeMade(Loc, Houses[I].PointBelowEntrance, tpWalk, 0) then Continue;
 
       Dist := KMLengthSqr(Loc, Houses[I].GetPosition);
 

--- a/src/houses/KM_Houses.pas
+++ b/src/houses/KM_Houses.pas
@@ -1640,7 +1640,7 @@ end;
 
 function TKMHouseWoodcutters.IsCuttingPointSet: Boolean;
 begin
-  Result := not KMSamePoint(fCuttingPoint, PointBelowEntrance);
+  Result := not KMSamePoint(CuttingPoint, PointBelowEntrance); //Use CuttingPoint, not fCuttingPoint to be sure its Valid
 end;
 
 

--- a/src/houses/KM_Houses.pas
+++ b/src/houses/KM_Houses.pas
@@ -72,6 +72,7 @@ type
 
     procedure MakeSound; dynamic; //Swine/stables make extra sounds
     function GetResDistribution(aID: Byte): Byte; //Will use GetRatio from mission settings to find distribution amount
+    function GetPointBelowEntrance: TKMPoint;
   protected
     fBuildState: THouseBuildState; // = (hbs_Glyph, hbs_NoGlyph, hbs_Wood, hbs_Stone, hbs_Done);
     FlagAnimStep: Cardinal; //Used for Flags and Burning animation
@@ -103,6 +104,7 @@ type
     property GetPosition: TKMPoint read fPosition;
     procedure SetPosition(aPos: TKMPoint); //Used only by map editor
     procedure OwnerUpdate(aOwner: TKMHandIndex);
+    property PointBelowEntrance: TKMPoint read GetPointBelowEntrance;
     function GetEntrance: TKMPoint;
     function GetClosestCell(aPos: TKMPoint): TKMPoint;
     function GetDistance(aPos: TKMPoint): Single;
@@ -1122,6 +1124,12 @@ begin
 end;
 
 
+function TKMHouse.GetPointBelowEntrance: TKMPoint;
+begin
+  Result := KMPointBelow(GetEntrance);
+end;
+
+
 function TKMHouse.GetResDistribution(aID: Byte): Byte;
 begin
   Result := gHands[fOwner].Stats.WareDistribution[gRes.Houses[fHouseType].ResInput[aID],fHouseType];
@@ -1610,7 +1618,7 @@ constructor TKMHouseWoodcutters.Create(aUID: Integer; aHouseType: THouseType; Po
 begin
   inherited;
   WoodcutterMode := wcm_ChopAndPlant;
-  CuttingPoint := KMPointBelow(GetEntrance);
+  CuttingPoint := PointBelowEntrance;
 end;
 
 

--- a/src/units/KM_UnitTaskBuild.pas
+++ b/src/units/KM_UnitTaskBuild.pas
@@ -685,7 +685,7 @@ begin
           OutOfWay := gTerrain.GetOutOfTheWay(fUnit, KMPoint(0,0), tpWalk);
           //GetOutOfTheWay can return the input position (GetPosition in this case) if no others are possible
           if KMSamePoint(OutOfWay, KMPoint(0,0)) or KMSamePoint(OutOfWay, GetPosition) then
-            OutOfWay := KMPointBelow(fHouse.GetEntrance); //Don't get stuck in corners
+            OutOfWay := fHouse.PointBelowEntrance; //Don't get stuck in corners
           SetActionWalkToSpot(OutOfWay);
           HouseNeedsWorker := False; //House construction no longer needs the worker to continue
           HouseReadyToBuild := True; //If worker gets killed while walking house will be finished without him

--- a/src/units/KM_UnitTaskDelivery.pas
+++ b/src/units/KM_UnitTaskDelivery.pas
@@ -178,7 +178,7 @@ begin
   with TKMUnitSerf(fUnit) do
   case fPhase of
     0:  begin
-          SetActionWalkToSpot(KMPointBelow(fFrom.GetEntrance));
+          SetActionWalkToSpot(fFrom.PointBelowEntrance);
         end;
     1:  begin
           SetActionGoIn(ua_Walk, gd_GoInside, fFrom);
@@ -210,7 +210,7 @@ begin
   with TKMUnitSerf(fUnit) do
   case fPhase of
     0..4:;
-    5:  SetActionWalkToSpot(KMPointBelow(fToHouse.GetEntrance));
+    5:  SetActionWalkToSpot(fToHouse.PointBelowEntrance);
     6:  SetActionGoIn(ua_Walk, gd_GoInside, fToHouse);
     7:  SetActionLockedStay(5, ua_Walk); //wait a bit inside
     8:  begin
@@ -245,7 +245,7 @@ begin
     //from any side, or something alike. Removing of Distance=1 from here simplifies our WalkToSpot method.
     //Since this change some people have complained because it's hard for serfs to get wares to the site
     //when workers block the enterance. But it is much simpler this way so we don't have a problem really.
-    5:  SetActionWalkToSpot(KMPointBelow(fToHouse.GetEntrance));
+    5:  SetActionWalkToSpot(fToHouse.PointBelowEntrance);
     6:  begin
           Direction := KMGetDirection(GetPosition, fToHouse.GetEntrance);
           fToHouse.ResAddToBuild(Carry);

--- a/src/units/KM_UnitTaskGoEat.pas
+++ b/src/units/KM_UnitTaskGoEat.pas
@@ -93,7 +93,7 @@ begin
         else
           SetActionLockedStay(0, ua_Walk); //Skip this step
       end;
-   1: SetActionWalkToSpot(KMPointBelow(fInn.GetEntrance));
+   1: SetActionWalkToSpot(fInn.PointBelowEntrance);
    2: begin
         SetActionGoIn(ua_Walk, gd_GoInside, fInn); //Enter Inn
         fPlace := fInn.EaterGetsInside(UnitType);

--- a/src/units/KM_UnitTaskGoHome.pas
+++ b/src/units/KM_UnitTaskGoHome.pas
@@ -40,7 +40,7 @@ begin
   case fPhase of
     0:  begin
           Thought := th_Home;
-          SetActionWalkToSpot(KMPointBelow(GetHome.GetEntrance));
+          SetActionWalkToSpot(GetHome.PointBelowEntrance);
         end;
     1:  SetActionGoIn(ua_Walk, gd_GoInside, GetHome);
     2:  begin

--- a/src/units/KM_UnitTaskGoOutShowHungry.pas
+++ b/src/units/KM_UnitTaskGoOutShowHungry.pas
@@ -45,7 +45,7 @@ begin
          GetHome.SetState(hst_Empty);
        end;
     2: SetActionLockedStay(4,ua_Walk);
-    3: SetActionWalkToSpot(KMPointBelow(fUnit.GetHome.GetEntrance));
+    3: SetActionWalkToSpot(fUnit.GetHome.PointBelowEntrance);
     4: SetActionGoIn(ua_Walk,gd_GoInside,fUnit.GetHome);
     5: begin
          SetActionStay(20+KaMRandom(10),ua_Walk);

--- a/src/units/KM_UnitTaskMining.pas
+++ b/src/units/KM_UnitTaskMining.pas
@@ -48,7 +48,7 @@ begin
   fWorkPlan.FindPlan( fUnit,
                       fUnit.GetHome.HouseType,
                       aWare,
-                      KMPointBelow(aUnit.GetHome.GetEntrance),
+                      aUnit.GetHome.PointBelowEntrance,
                       ChooseToCutOrPlant
                       );
 end;
@@ -136,7 +136,7 @@ begin
   OldDir := WorkPlan.WorkDir;
 
   //Tell the work plan to find a new resource of the same gathering script
-  if WorkPlan.FindDifferentResource(fUnit, KMPointBelow(fUnit.GetHome.GetEntrance), OldLoc) then
+  if WorkPlan.FindDifferentResource(fUnit, fUnit.GetHome.PointBelowEntrance, OldLoc) then
   begin
     //Must always give us a new location (or same location but different direction)
     Assert((OldDir <> WorkPlan.WorkDir) or not KMSamePoint(OldLoc, WorkPlan.Loc));
@@ -304,7 +304,7 @@ begin
        end;
     7: begin
          //Removing the tree and putting a stump is handled in gTerrain.UpdateState from FallingTrees list
-         SetActionWalkToSpot(KMPointBelow(GetHome.GetEntrance), WorkPlan.ActionWalkFrom); //Go home
+         SetActionWalkToSpot(GetHome.PointBelowEntrance, WorkPlan.ActionWalkFrom); //Go home
          Thought := th_Home;
        end;
     8: SetActionGoIn(WorkPlan.ActionWalkFrom, gd_GoInside, GetHome); //Go inside

--- a/src/units/KM_Units.pas
+++ b/src/units/KM_Units.pas
@@ -453,7 +453,7 @@ begin
     ht_IronMine:    Msg := TX_MSG_IRON_DEPLETED;
     ht_GoldMine:    Msg := TX_MSG_GOLD_DEPLETED;
     ht_Woodcutters: Msg := TX_MSG_WOODCUTTER_DEPLETED;
-    ht_FisherHut:   if not gTerrain.CanFindFishingWater(KMPointBelow(fHome.GetEntrance), gRes.Units[fUnitType].MiningRange) then
+    ht_FisherHut:   if not gTerrain.CanFindFishingWater(fHome.PointBelowEntrance, gRes.Units[fUnitType].MiningRange) then
                       Msg := TX_MSG_FISHERMAN_TOO_FAR
                     else
                       Msg := TX_MSG_FISHERMAN_CANNOT_CATCH;
@@ -1278,7 +1278,7 @@ end;
 
 function TKMUnit.CanAccessHome: Boolean;
 begin
-  Result := (fHome = nil) or CanWalkTo(KMPointBelow(fHome.GetEntrance), tpWalk, 0);
+  Result := (fHome = nil) or CanWalkTo(fHome.PointBelowEntrance, tpWalk, 0);
 end;
 
 


### PR DESCRIPTION
Sorry, but there are two things in one PR:
1) actual bug fix. It is in the next units: KM_Houses/KM_HouseBarracks/KM_Terrain.
2) refactoring: instead of using KMPointBelow(House.GetEntrance) new house property PointBelowEntrance introduces. Then we can simplify code a bit, reduce amount of brackets

BugFix:
we will set new rally/cutting point within segment between current (invalid) point and point below house entrance. Check is acquired in point getter method, then it will never used as invalid outside of TKMHouseBarracks/TKMHouseWoodcutters.

To get this new point within segment new method TKMTerrain.GetPassablePointWithinSegment is introduced.