### PR TITLE
Error PR. Map Editor: ability to set barracks rally point/woodcutters cutting point

### DIFF
--- a/src/KM_Defaults.pas
+++ b/src/KM_Defaults.pas
@@ -258,8 +258,7 @@ type
     cmSelection, //Selection manipulations
     cmUnits, //Units
     cmMarkers, //CenterScreen, Defence, FOW markers
-    cmEyedropper, //Terrain eyedropper
-    cmRallyPoint
+    cmEyedropper //Terrain eyedropper
     );
 
 type

--- a/src/KM_Defaults.pas
+++ b/src/KM_Defaults.pas
@@ -258,7 +258,8 @@ type
     cmSelection, //Selection manipulations
     cmUnits, //Units
     cmMarkers, //CenterScreen, Defence, FOW markers
-    cmEyedropper //Terrain eyedropper
+    cmEyedropper, //Terrain eyedropper
+    cmRallyPoint
     );
 
 type

--- a/src/KM_MissionScript.pas
+++ b/src/KM_MissionScript.pas
@@ -20,7 +20,7 @@ type
                     ct_SetHouseDamage,ct_SetUnitByStock,ct_UnitAddToLast,ct_SetGroup,ct_SetGroupFood,ct_SendGroup,
                     ct_AttackPosition,ct_AddWareToSecond,ct_AddWareTo,ct_AddWareToLast,ct_AddWareToAll,ct_AddWeapon,ct_AICharacter,
                     ct_AINoBuild,ct_AIAutoRepair,ct_AIAutoAttack,ct_AIAutoDefend,ct_AIDefendAllies,ct_AIUnlimitedEquip,ct_AIArmyType,
-                    ct_AIStartPosition,ct_AIDefence,ct_AIAttack,ct_CopyAIAttack,ct_ClearAIAttack);
+                    ct_AIStartPosition,ct_AIDefence,ct_AIAttack,ct_CopyAIAttack,ct_ClearAIAttack, ct_SetRallyPoint);
 
 const
   COMMANDVALUES: array [TKMCommandType] of AnsiString = (
@@ -45,7 +45,8 @@ const
     'SET_AI_NO_BUILD','SET_AI_AUTO_REPAIR','SET_AI_AUTO_ATTACK','SET_AI_AUTO_DEFEND',
     'SET_AI_DEFEND_ALLIES','SET_AI_UNLIMITED_EQUIP','SET_AI_ARMY_TYPE','SET_AI_START_POSITION',
     'SET_AI_DEFENSE','SET_AI_ATTACK',
-    'COPY_AI_ATTACK','CLEAR_AI_ATTACK');
+    'COPY_AI_ATTACK','CLEAR_AI_ATTACK',
+    'SET_RALLY_POINT');
 
 type
   TMissionParserCommon = class

--- a/src/KM_MissionScript_Standard.pas
+++ b/src/KM_MissionScript_Standard.pas
@@ -553,19 +553,16 @@ begin
                         end;
     ct_SetRallyPoint:   begin
                           if fLastHand <> PLAYER_NONE then
-                            if (fLastHouse <> nil) and (fLastHouse is TKMHouseBarracks) then
+                            if (fLastHouse <> nil) then
                             begin
                               if not fLastHouse.IsDestroyed then //Could be destroyed already by damage
-                                TKMHouseBarracks(fLastHouse).RallyPoint := KMPoint(P[0], P[1]);
+                                if (fLastHouse is TKMHouseBarracks) then
+                                  TKMHouseBarracks(fLastHouse).RallyPoint := KMPoint(P[0], P[1])
+                                else if (fLastHouse is TKMHouseWoodcutters) then
+                                  TKMHouseWoodcutters(fLastHouse).CuttingPoint := KMPoint(P[0], P[1]);
                             end
                             else
                               AddError('ct_SetRallyPoint without prior declaration of House');
-                            if InRange(P[0], Low(HouseIndexToType), High(HouseIndexToType)) then
-                              if gTerrain.CanPlaceHouseFromScript(HouseIndexToType[P[0]], KMPoint(P[1]+1, P[2]+1)) then
-                                fLastHouse := gHands[fLastHand].AddHouse(
-                                  HouseIndexToType[P[0]], P[1]+1, P[2]+1, false)
-                              else
-                                AddError('ct_SetHouse failed, can not place house at ' + TypeToString(KMPoint(P[1]+1, P[2]+1)));
                         end;
 
     ct_EnablePlayer:    begin
@@ -847,6 +844,12 @@ begin
             AddCommand(ct_UnitAddToLast, [UnitTypeToOldIndex[ut_Recruit]]);
           if TKMHouseBarracks(H).IsRallyPointSet then
             AddCommand(ct_SetRallyPoint, [TKMHouseBarracks(H).RallyPoint.X, TKMHouseBarracks(H).RallyPoint.Y]);
+        end;
+
+        if H is TKMHouseWoodcutters then
+        begin
+          if TKMHouseWoodcutters(H).IsCuttingPointSet then
+            AddCommand(ct_SetRallyPoint, [TKMHouseWoodcutters(H).CuttingPoint.X, TKMHouseWoodcutters(H).CuttingPoint.Y]);
         end;
 
         //Process any wares in this house

--- a/src/KM_MissionScript_Standard.pas
+++ b/src/KM_MissionScript_Standard.pas
@@ -551,6 +551,22 @@ begin
                         begin
                           FillChar(fAIAttack, SizeOf(fAIAttack), #0);
                         end;
+    ct_SetRallyPoint:   begin
+                          if fLastHand <> PLAYER_NONE then
+                            if (fLastHouse <> nil) and (fLastHouse is TKMHouseBarracks) then
+                            begin
+                              if not fLastHouse.IsDestroyed then //Could be destroyed already by damage
+                                TKMHouseBarracks(fLastHouse).RallyPoint := KMPoint(P[0], P[1]);
+                            end
+                            else
+                              AddError('ct_SetRallyPoint without prior declaration of House');
+                            if InRange(P[0], Low(HouseIndexToType), High(HouseIndexToType)) then
+                              if gTerrain.CanPlaceHouseFromScript(HouseIndexToType[P[0]], KMPoint(P[1]+1, P[2]+1)) then
+                                fLastHouse := gHands[fLastHand].AddHouse(
+                                  HouseIndexToType[P[0]], P[1]+1, P[2]+1, false)
+                              else
+                                AddError('ct_SetHouse failed, can not place house at ' + TypeToString(KMPoint(P[1]+1, P[2]+1)));
+                        end;
 
     ct_EnablePlayer:    begin
                           //Serves no real purpose, all players have this command anyway
@@ -826,8 +842,12 @@ begin
           AddCommand(ct_SetHouseDamage, [H.GetDamage]);
 
         if H is TKMHouseBarracks then
+        begin
           for J := 1 to TKMHouseBarracks(H).MapEdRecruitCount do
             AddCommand(ct_UnitAddToLast, [UnitTypeToOldIndex[ut_Recruit]]);
+          if TKMHouseBarracks(H).IsRallyPointSet then
+            AddCommand(ct_SetRallyPoint, [TKMHouseBarracks(H).RallyPoint.X, TKMHouseBarracks(H).RallyPoint.Y]);
+        end;
 
         //Process any wares in this house
         //First two Stores use special KaM commands
@@ -945,3 +965,4 @@ end;
 
 
 end.
+

--- a/src/gui/KM_InterfaceMapEditor.pas
+++ b/src/gui/KM_InterfaceMapEditor.pas
@@ -855,6 +855,7 @@ begin
                   end;
                 end;
               end;
+
     mbRight:  begin
                 //Right click performs some special functions and shortcuts
                 if gGameCursor.Mode = cmTiles then

--- a/src/gui/KM_InterfaceMapEditor.pas
+++ b/src/gui/KM_InterfaceMapEditor.pas
@@ -838,7 +838,9 @@ begin
                 cmRallyPoint: begin
                                 gMySpectator.UpdateSelect;
                                 if gMySpectator.Selected is TKMHouseBarracks then
-                                  TKMHouseBarracks(gMySpectator.Selected).RallyPoint := gGameCursor.Cell;
+                                  TKMHouseBarracks(gMySpectator.Selected).RallyPoint := gGameCursor.Cell
+                                else if gMySpectator.Selected is TKMHouseWoodcutters then
+                                  TKMHouseWoodcutters(gMySpectator.Selected).CuttingPoint := gGameCursor.Cell;
                               end;
               end;
     mbRight:  begin
@@ -855,7 +857,16 @@ begin
 
                 //Move the selected object to the cursor location
                 if gMySpectator.Selected is TKMHouse then
-                  TKMHouse(gMySpectator.Selected).SetPosition(gGameCursor.Cell); //Can place is checked in SetPosition
+                begin
+                  if ssShift in Shift then
+                  begin
+                    if gMySpectator.Selected is TKMHouseBarracks then
+                      TKMHouseBarracks(gMySpectator.Selected).RallyPoint := gGameCursor.Cell
+                    else if gMySpectator.Selected is TKMHouseWoodcutters then
+                      TKMHouseWoodcutters(gMySpectator.Selected).CuttingPoint := gGameCursor.Cell;
+                  end else
+                    TKMHouse(gMySpectator.Selected).SetPosition(gGameCursor.Cell); //Can place is checked in SetPosition
+                end;
 
                 if gMySpectator.Selected is TKMUnit then
                   TKMUnit(gMySpectator.Selected).SetPosition(gGameCursor.Cell);

--- a/src/gui/KM_InterfaceMapEditor.pas
+++ b/src/gui/KM_InterfaceMapEditor.pas
@@ -745,7 +745,9 @@ begin
     fMouseDownOnMap := True;
 
   UpdateGameCursor(X,Y,Shift);
-  if gGameCursor.Mode = cmRallyPoint then
+
+  //Check if we are in RallyPointMode
+  if fGuiHouse.RallyPointMode then
     gRes.Cursors.Cursor := kmc_Beacon
   else
   if gGameCursor.Mode = cmNone then
@@ -801,56 +803,58 @@ begin
   fMouseDownOnMap := False;
 
   case Button of
-    mbLeft:   case gGameCursor.Mode of
-                cmNone:       begin
-                                //If there are some additional layers we first HitTest them
-                                //since they are rendered ontop of Houses/Objects
-                                Marker := gGame.MapEditor.HitTest(gGameCursor.Cell.X, gGameCursor.Cell.Y);
-                                if Marker.MarkerType <> mtNone then
-                                begin
-                                  ShowMarkerInfo(Marker);
-                                  gMySpectator.Selected := nil; //We might have had a unit/group/house selected
-                                end
-                                else
-                                begin
-                                  gMySpectator.UpdateSelect;
+    mbLeft:   if gGameCursor.Mode = cmNone then
+              begin
+                //If there are some additional layers we first HitTest them
+                //since they are rendered ontop of Houses/Objects
+                Marker := gGame.MapEditor.HitTest(gGameCursor.Cell.X, gGameCursor.Cell.Y);
 
-                                  if gMySpectator.Selected is TKMHouse then
-                                  begin
-                                    HidePages;
-                                    Player_SetActive(TKMHouse(gMySpectator.Selected).Owner);
-                                    fGuiHouse.Show(TKMHouse(gMySpectator.Selected));
-                                  end;
-                                  if gMySpectator.Selected is TKMUnit then
-                                  begin
-                                    HidePages;
-                                    Player_SetActive(TKMUnit(gMySpectator.Selected).Owner);
-                                    fGuiUnit.Show(TKMUnit(gMySpectator.Selected));
-                                  end;
-                                  if gMySpectator.Selected is TKMUnitGroup then
-                                  begin
-                                    HidePages;
-                                    Player_SetActive(TKMUnitGroup(gMySpectator.Selected).Owner);
-                                    fGuiUnit.Show(TKMUnitGroup(gMySpectator.Selected));
-                                  end;
-                                end;
-                              end;
-                cmRallyPoint: begin
-                                gMySpectator.UpdateSelect;
-                                if gMySpectator.Selected is TKMHouseBarracks then
-                                  TKMHouseBarracks(gMySpectator.Selected).RallyPoint := gGameCursor.Cell
-                                else if gMySpectator.Selected is TKMHouseWoodcutters then
-                                  TKMHouseWoodcutters(gMySpectator.Selected).CuttingPoint := gGameCursor.Cell;
-                              end;
+                if fGuiHouse.RallyPointMode then
+                begin
+                  if gMySpectator.Selected is TKMHouseBarracks then
+                    TKMHouseBarracks(gMySpectator.Selected).RallyPoint := gGameCursor.Cell
+                  else if gMySpectator.Selected is TKMHouseWoodcutters then
+                    TKMHouseWoodcutters(gMySpectator.Selected).CuttingPoint := gGameCursor.Cell;
+                  Exit;
+                end;
+
+                if Marker.MarkerType <> mtNone then
+                begin
+                  ShowMarkerInfo(Marker);
+                  gMySpectator.Selected := nil; //We might have had a unit/group/house selected
+                end
+                else
+                begin
+                  gMySpectator.UpdateSelect;
+
+                  if gMySpectator.Selected is TKMHouse then
+                  begin
+                    HidePages;
+                    Player_SetActive(TKMHouse(gMySpectator.Selected).Owner);
+                    fGuiHouse.Show(TKMHouse(gMySpectator.Selected));
+                  end;
+                  if gMySpectator.Selected is TKMUnit then
+                  begin
+                    HidePages;
+                    Player_SetActive(TKMUnit(gMySpectator.Selected).Owner);
+                    fGuiUnit.Show(TKMUnit(gMySpectator.Selected));
+                  end;
+                  if gMySpectator.Selected is TKMUnitGroup then
+                  begin
+                    HidePages;
+                    Player_SetActive(TKMUnitGroup(gMySpectator.Selected).Owner);
+                    fGuiUnit.Show(TKMUnitGroup(gMySpectator.Selected));
+                  end;
+                end;
               end;
     mbRight:  begin
                 //Right click performs some special functions and shortcuts
                 if gGameCursor.Mode = cmTiles then
                   gGameCursor.MapEdDir := (gGameCursor.MapEdDir + 1) mod 4; //Rotate tile direction
 
-                if gGameCursor.Mode = cmRallyPoint then
+                if fGuiHouse.RallyPointMode then
                 begin
-                  gGameCursor.Mode := cmNone;
+                  fGuiHouse.RallyPointMode := False;
                   gRes.Cursors.Cursor := kmc_Default;
                   Exit;
                 end;

--- a/src/gui/KM_InterfaceMapEditor.pas
+++ b/src/gui/KM_InterfaceMapEditor.pas
@@ -61,7 +61,6 @@ type
     procedure ShowMarkerInfo(aMarker: TKMMapEdMarker);
     procedure Player_SetActive(aIndex: TKMHandIndex);
     procedure Player_UpdatePages;
-    procedure UpdatePlayerSelectButtons;
   protected
     MinimapView: TKMMinimapView;
     Label_Coordinates: TKMLabel;
@@ -313,19 +312,13 @@ begin
 end;
 
 
-procedure TKMapEdInterface.UpdatePlayerSelectButtons;
+
+//Should update any items changed by game (resource counts, hp, etc..)
+procedure TKMapEdInterface.UpdateState(aTickCount: Cardinal);
 const
   CAP_COLOR: array [Boolean] of Cardinal = ($80808080, $FFFFFFFF);
 var
   I: Integer;
-begin
-  for I := 0 to MAX_HANDS - 1 do
-    Button_PlayerSelect[I].FontColor := CAP_COLOR[gHands[I].HasAssets];
-end;
-
-
-//Should update any items changed by game (resource counts, hp, etc..)
-procedure TKMapEdInterface.UpdateState(aTickCount: Cardinal);
 begin
   //Update minimap every 1000ms
   if aTickCount mod 10 = 0 then
@@ -333,8 +326,9 @@ begin
 
   //Show players without assets in grey
   if aTickCount mod 10 = 0 then
-    UpdatePlayerSelectButtons;
-                 
+  for I := 0 to MAX_HANDS - 1 do
+    Button_PlayerSelect[I].FontColor := CAP_COLOR[gHands[I].HasAssets];
+
   fGuiHouse.UpdateState;
   fGuiTerrain.UpdateState;
   fGuiMenu.UpdateState;
@@ -365,8 +359,6 @@ begin
     Button_PlayerSelect[I].ShapeColor := gHands[I].FlagColor;
 
   Player_UpdatePages;
-
-  UpdatePlayerSelectButtons;
 
   Label_MissionName.Caption := gGame.GameName;
 end;

--- a/src/gui/pages_maped/KM_GUIMapEdHouse.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdHouse.pas
@@ -15,13 +15,16 @@ type
 
     procedure Create_Store;
     procedure Create_Barracks;
+    procedure Create_Woodcutters;
 
     procedure HouseChange(Sender: TObject; Shift: TShiftState);
-    procedure BarracksRefresh(Sender: TObject);
+    procedure BarracksRefresh;
+    procedure WoodcuttersRefresh;
     procedure BarracksSelectWare(Sender: TObject);
     procedure BarracksSetRallyPoint(Sender: TObject);
+    procedure WoodcuttersSetRallyPoint(Sender: TObject);
     procedure BarracksChange(Sender: TObject; Shift: TShiftState);
-    procedure StoreRefresh(Sender: TObject);
+    procedure StoreRefresh;
     procedure StoreSelectWare(Sender: TObject);
     procedure StoreChange(Sender: TObject; Shift: TShiftState);
   protected
@@ -33,6 +36,9 @@ type
       Label_House_Input, Label_House_Output: TKMLabel;
       ResRow_Resource_Input: array [0..3] of TKMWareOrderRow;
       ResRow_Resource_Output: array [0..3] of TKMWareOrderRow;
+
+    Panel_HouseWoodcutters: TKMPanel;
+      Button_Woodcutters_CuttingPoint: TKMButtonFlat;
 
     Panel_HouseStore: TKMPanel;
       Button_Store: array [1..STORE_RES_COUNT] of TKMButtonFlat;
@@ -106,6 +112,7 @@ begin
 
   Create_Store;
   Create_Barracks;
+  Create_Woodcutters;
 end;
 
 
@@ -139,15 +146,33 @@ begin
 end;
 
 
+procedure TKMMapEdHouse.Create_Woodcutters;
+begin
+  Panel_HouseWoodcutters := TKMPanel.Create(Panel_House,0,85,TB_WIDTH,40);
+    Button_Woodcutters_CuttingPoint := TKMButtonFlat.Create(Panel_HouseWoodcutters, 0, 0, TB_WIDTH, 22, 0);
+    Button_Woodcutters_CuttingPoint.CapOffsetY := -11;
+    Button_Woodcutters_CuttingPoint.Caption := 'Cutting point'; //Todo translate
+    Button_Woodcutters_CuttingPoint.Hint := 'Set Woodcutters cutting point'; //Todo translate
+    Button_Woodcutters_CuttingPoint.OnClick := WoodcuttersSetRallyPoint;
+end;
+
+
 {Barracks page}
 procedure TKMMapEdHouse.Create_Barracks;
 var
   I: Integer;
 begin
   Panel_HouseBarracks:=TKMPanel.Create(Panel_House,0,76,TB_WIDTH,400);
+
+    Button_Barracks_RallyPoint := TKMButtonFlat.Create(Panel_HouseBarracks, 0, 8, TB_WIDTH, 22, 0);
+    Button_Barracks_RallyPoint.CapOffsetY := -11;
+    Button_Barracks_RallyPoint.Caption := 'Rally point'; //Todo translate
+    Button_Barracks_RallyPoint.Hint := 'Set Barracks rally point'; //Todo translate
+    Button_Barracks_RallyPoint.OnClick := BarracksSetRallyPoint;
+
     for I := 1 to BARRACKS_RES_COUNT do
     begin
-      Button_Barracks[I]:=TKMButtonFlat.Create(Panel_HouseBarracks, ((I-1)mod 6)*31,8+((I-1)div 6)*42,28,38,0);
+      Button_Barracks[I]:=TKMButtonFlat.Create(Panel_HouseBarracks, ((I-1)mod 6)*31,26+8+((I-1)div 6)*42,28,38,0);
       Button_Barracks[I].Tag := I;
       Button_Barracks[I].TexID := gRes.Wares[BarracksResType[I]].GUIIcon;
       Button_Barracks[I].TexOffsetX := 1;
@@ -156,7 +181,7 @@ begin
       Button_Barracks[I].Hint := gRes.Wares[BarracksResType[I]].Title;
       Button_Barracks[I].OnClick := BarracksSelectWare;
     end;
-    Button_Barracks_Recruit := TKMButtonFlat.Create(Panel_HouseBarracks, (BARRACKS_RES_COUNT mod 6)*31,8+(BARRACKS_RES_COUNT div 6)*42,28,38,0);
+    Button_Barracks_Recruit := TKMButtonFlat.Create(Panel_HouseBarracks, (BARRACKS_RES_COUNT mod 6)*31,26+8+(BARRACKS_RES_COUNT div 6)*42,28,38,0);
     Button_Barracks_Recruit.Tag := -1;
     Button_Barracks_Recruit.TexOffsetX := 1;
     Button_Barracks_Recruit.TexOffsetY := 1;
@@ -164,13 +189,6 @@ begin
     Button_Barracks_Recruit.TexID := gRes.Units[ut_Recruit].GUIIcon;
     Button_Barracks_Recruit.Hint := gRes.Units[ut_Recruit].GUIName;
     Button_Barracks_Recruit.OnClick := BarracksSelectWare;
-
-    Button_Barracks_RallyPoint := TKMButtonFlat.Create(Panel_HouseBarracks, 0, 8+42+38+10,30,30,322);
-    Button_Barracks_RallyPoint.TexOffsetX := 1;
-    Button_Barracks_RallyPoint.TexOffsetY := 1;
-    Button_Barracks_RallyPoint.CapOffsetY := 2;
-    Button_Barracks_RallyPoint.Hint := 'Set barracks rally point'; //Todo translate
-    Button_Barracks_RallyPoint.OnClick := BarracksSetRallyPoint;
 
     Button_BarracksDec100     := TKMButton.Create(Panel_HouseBarracks,108,218,20,20,'<', bsGame);
     Button_BarracksDec100.Tag := 100;
@@ -204,7 +222,8 @@ procedure TKMMapEdHouse.UpdateState;
 begin
   if Visible then
     case fHouse.HouseType of
-      ht_Barracks: Button_Barracks_RallyPoint.Down := gGameCursor.Mode = cmRallyPoint;
+      ht_Barracks:    Button_Barracks_RallyPoint.Down := gGameCursor.Mode = cmRallyPoint;
+      ht_Woodcutters: Button_Woodcutters_CuttingPoint.Down := gGameCursor.Mode = cmRallyPoint;
     end;
 end;
 
@@ -267,32 +286,38 @@ begin
   end;
 
   case fHouse.HouseType of
-    ht_Store:     begin
-                    Panel_HouseStore.Show;
-                    StoreRefresh(nil);
-                    //Reselect the ware so the display is updated
-                    StoreSelectWare(Button_Store[fStorehouseItem]);
-                  end;
-    ht_Barracks:  begin
-                    Panel_HouseBarracks.Show;
-                    BarracksRefresh(nil);
-                    //In the barrack the recruit icon is always enabled
-                    Image_House_Worker.Enable;
-                    Button_Barracks_Recruit.FlagColor := gHands[fHouse.Owner].FlagColor;
-                    Button_Barracks_RallyPoint.FlagColor := gHands[fHouse.Owner].FlagColor;;
-                    //Reselect the ware so the display is updated
-                    if fBarracksItem = -1 then
-                      BarracksSelectWare(Button_Barracks_Recruit)
-                    else
-                      BarracksSelectWare(Button_Barracks[fBarracksItem]);
-                  end;
+    ht_Store:       begin
+                      Panel_HouseStore.Show;
+                      StoreRefresh;
+                      //Reselect the ware so the display is updated
+                      StoreSelectWare(Button_Store[fStorehouseItem]);
+                    end;
+    ht_Barracks:   begin
+                      Panel_HouseBarracks.Show;
+                      BarracksRefresh;
+                      //In the barrack the recruit icon is always enabled
+                      Image_House_Worker.Enable;
+                      Button_Barracks_Recruit.FlagColor := gHands[fHouse.Owner].FlagColor;
+                      //Reselect the ware so the display is updated
+                      if fBarracksItem = -1 then
+                        BarracksSelectWare(Button_Barracks_Recruit)
+                      else
+                        BarracksSelectWare(Button_Barracks[fBarracksItem]);
+                    end;
+    ht_Woodcutters: begin
+                      Panel_HouseWoodcutters.Show;
+                      WoodcuttersRefresh;
+                    end;
     ht_TownHall:;
-    else          Panel_House.Show;
+    else            begin
+                      Panel_HouseWoodcutters.Hide;
+                      Panel_House.Show;
+                    end;
   end;
 end;
 
 
-procedure TKMMapEdHouse.StoreRefresh(Sender: TObject);
+procedure TKMMapEdHouse.StoreRefresh;
 var
   I, Tmp: Integer;
 begin
@@ -304,7 +329,7 @@ begin
 end;
 
 
-procedure TKMMapEdHouse.BarracksRefresh(Sender: TObject);
+procedure TKMMapEdHouse.BarracksRefresh;
 var
   I, Tmp: Integer;
 begin
@@ -316,6 +341,12 @@ begin
   Tmp := TKMHouseBarracks(fHouse).MapEdRecruitCount;
   Button_Barracks_Recruit.Caption := IfThen(Tmp = 0, '-', IntToStr(Tmp));
   Button_Barracks_RallyPoint.Down := gGameCursor.Mode = cmRallyPoint;
+end;
+
+
+procedure TKMMapEdHouse.WoodcuttersRefresh;
+begin
+  Button_Woodcutters_CuttingPoint.Down := gGameCursor.Mode = cmRallyPoint;
 end;
 
 
@@ -381,6 +412,17 @@ procedure TKMMapEdHouse.BarracksSetRallyPoint(Sender: TObject);
 begin
   Button_Barracks_RallyPoint.Down := not Button_Barracks_RallyPoint.Down;
   if Button_Barracks_RallyPoint.Down then
+  begin
+    gGameCursor.Mode := cmRallyPoint;
+  end else
+    gGameCursor.Mode := cmNone;
+end;
+
+
+procedure TKMMapEdHouse.WoodcuttersSetRallyPoint(Sender: TObject);
+begin
+  Button_Woodcutters_CuttingPoint.Down := not Button_Woodcutters_CuttingPoint.Down;
+  if Button_Woodcutters_CuttingPoint.Down then
   begin
     gGameCursor.Mode := cmRallyPoint;
   end else
@@ -459,7 +501,7 @@ begin
 
     Label_Barracks_WareCount.Caption := IntToStr(Barracks.CheckResIn(Res));
   end;
-  BarracksRefresh(nil);
+  BarracksRefresh;
 end;
 
 
@@ -483,7 +525,7 @@ begin
     Store.ResAddToIn(Res, GetMultiplicator(Shift) * TKMButton(Sender).Tag);
 
   Label_Store_WareCount.Caption := inttostr(Store.CheckResIn(Res));
-  StoreRefresh(nil);
+  StoreRefresh;
 end;
 
 

--- a/src/gui/pages_maped/KM_GUIMapEdHouse.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdHouse.pas
@@ -69,7 +69,7 @@ type
 implementation
 uses
   KM_HandsCollection, KM_ResTexts, KM_Resource, KM_RenderUI, KM_Hand, KM_ResUnits,
-  KM_ResWares, KM_ResCursors, KM_HouseBarracks, KM_ResFonts, KM_Utils, KM_GameCursor;
+  KM_ResWares, KM_HouseBarracks, KM_ResFonts, KM_Utils;
 
 
 { TKMMapEdHouse }
@@ -157,7 +157,7 @@ begin
     Button_Woodcutters_CuttingPoint := TKMButtonFlat.Create(Panel_HouseWoodcutters, 0, 0, TB_WIDTH, 22, 0);
     Button_Woodcutters_CuttingPoint.CapOffsetY := -11;
     Button_Woodcutters_CuttingPoint.Caption := 'Cutting point'; //Todo translate
-    Button_Woodcutters_CuttingPoint.Hint := 'Set Woodcutters cutting point'; //Todo translate
+    Button_Woodcutters_CuttingPoint.Hint := 'Set woodcutters cutting point. Alternatively you can set it via Shift + Right mouse button'; //Todo translate
     Button_Woodcutters_CuttingPoint.OnClick := WoodcuttersSetRallyPoint;
 end;
 
@@ -172,7 +172,7 @@ begin
     Button_Barracks_RallyPoint := TKMButtonFlat.Create(Panel_HouseBarracks, 0, 8, TB_WIDTH, 22, 0);
     Button_Barracks_RallyPoint.CapOffsetY := -11;
     Button_Barracks_RallyPoint.Caption := 'Rally point'; //Todo translate
-    Button_Barracks_RallyPoint.Hint := 'Set Barracks rally point'; //Todo translate
+    Button_Barracks_RallyPoint.Hint := 'Set barracks rally point. Alternatively you can set it via Shift + Right mouse button'; //Todo translate
     Button_Barracks_RallyPoint.OnClick := BarracksSetRallyPoint;
 
     for I := 1 to BARRACKS_RES_COUNT do

--- a/src/gui/pages_maped/KM_GUIMapEdHouse.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdHouse.pas
@@ -10,6 +10,8 @@ type
   private
     fHouse: TKMHouse;
 
+    fRallyPointMode: Boolean;
+
     fStorehouseItem: Byte; //Selected ware in storehouse
     fBarracksItem: ShortInt; //Selected ware in barracks, or -1 for recruit
 
@@ -56,6 +58,7 @@ type
   public
     constructor Create(aParent: TKMPanel);
 
+    property RallyPointMode: Boolean read fRallyPointMode write fRallyPointMode;
     procedure Show(aHouse: TKMHouse);
     procedure Hide;
     function Visible: Boolean;
@@ -75,6 +78,8 @@ var
   I: Integer;
 begin
   inherited Create;
+
+  fRallyPointMode := False;
 
   fBarracksItem   := 1; //First ware selected by default
   fStorehouseItem := 1; //First ware selected by default
@@ -222,8 +227,8 @@ procedure TKMMapEdHouse.UpdateState;
 begin
   if Visible then
     case fHouse.HouseType of
-      ht_Barracks:    Button_Barracks_RallyPoint.Down := gGameCursor.Mode = cmRallyPoint;
-      ht_Woodcutters: Button_Woodcutters_CuttingPoint.Down := gGameCursor.Mode = cmRallyPoint;
+      ht_Barracks:    Button_Barracks_RallyPoint.Down := fRallyPointMode;
+      ht_Woodcutters: Button_Woodcutters_CuttingPoint.Down := fRallyPointMode;
     end;
 end;
 
@@ -340,13 +345,13 @@ begin
   end;
   Tmp := TKMHouseBarracks(fHouse).MapEdRecruitCount;
   Button_Barracks_Recruit.Caption := IfThen(Tmp = 0, '-', IntToStr(Tmp));
-  Button_Barracks_RallyPoint.Down := gGameCursor.Mode = cmRallyPoint;
+  Button_Barracks_RallyPoint.Down := fRallyPointMode;
 end;
 
 
 procedure TKMMapEdHouse.WoodcuttersRefresh;
 begin
-  Button_Woodcutters_CuttingPoint.Down := gGameCursor.Mode = cmRallyPoint;
+  Button_Woodcutters_CuttingPoint.Down := fRallyPointMode;
 end;
 
 
@@ -410,23 +415,15 @@ end;
 
 procedure TKMMapEdHouse.BarracksSetRallyPoint(Sender: TObject);
 begin
-  Button_Barracks_RallyPoint.Down := not Button_Barracks_RallyPoint.Down;
-  if Button_Barracks_RallyPoint.Down then
-  begin
-    gGameCursor.Mode := cmRallyPoint;
-  end else
-    gGameCursor.Mode := cmNone;
+  fRallyPointMode := not Button_Barracks_RallyPoint.Down;
+  Button_Barracks_RallyPoint.Down := fRallyPointMode;
 end;
 
 
 procedure TKMMapEdHouse.WoodcuttersSetRallyPoint(Sender: TObject);
 begin
-  Button_Woodcutters_CuttingPoint.Down := not Button_Woodcutters_CuttingPoint.Down;
-  if Button_Woodcutters_CuttingPoint.Down then
-  begin
-    gGameCursor.Mode := cmRallyPoint;
-  end else
-    gGameCursor.Mode := cmNone;
+  fRallyPointMode := not Button_Woodcutters_CuttingPoint.Down;
+  Button_Woodcutters_CuttingPoint.Down := fRallyPointMode;
 end;
 
 

--- a/src/houses/KM_HouseBarracks.pas
+++ b/src/houses/KM_HouseBarracks.pas
@@ -15,6 +15,7 @@ type
     fResourceCount: array [WARFARE_MIN..WARFARE_MAX] of Word;
     fRallyPoint: TKMPoint;
     function GetRallyPoint: TKMPoint;
+    procedure SetRallyPoint(aRallyPoint: TKMPoint);
   public
     MapEdRecruitCount: Word; //Only used by MapEd
     NotAcceptFlag: array [WARFARE_MIN .. WARFARE_MAX] of Boolean;
@@ -31,7 +32,7 @@ type
     function CheckResIn(aWare: TWareType): Word; override;
     function ResCanAddToIn(aRes: TWareType): Boolean; override;
 
-    property RallyPoint: TKMPoint read GetRallyPoint write fRallyPoint;
+    property RallyPoint: TKMPoint read GetRallyPoint write SetRallyPoint;
 
     function ResOutputAvailable(aRes: TWareType; const aCount: Word): Boolean; override;
     function CanEquip(aUnitType: TUnitType): Boolean;
@@ -277,11 +278,17 @@ begin
 end;
 
 
+procedure TKMHouseBarracks.SetRallyPoint(aRallyPoint: TKMPoint);
+begin
+  fRallyPoint := gTerrain.GetPassablePointWithinSegment(PointBelowEntrance, aRallyPoint, tpWalk);
+end;
+
+
 function TKMHouseBarracks.GetRallyPoint: TKMPoint;
 begin
   if not gTerrain.CheckPassability(fRallyPoint, tpWalk) then
     //update rally point if its not valid (not walkable). Set it closer to barracks entrance (PointBelowEntrance)
-    fRallyPoint := gTerrain.GetPassablePointWithinSegment(PointBelowEntrance, fRallyPoint, tpWalk);
+    SetRallyPoint(fRallyPoint);
   Result := fRallyPoint;
 end;
 

--- a/src/houses/KM_HouseBarracks.pas
+++ b/src/houses/KM_HouseBarracks.pas
@@ -33,6 +33,7 @@ type
     function ResCanAddToIn(aRes: TWareType): Boolean; override;
 
     property RallyPoint: TKMPoint read GetRallyPoint write SetRallyPoint;
+    procedure ValidateNUpdateRallyPoint;
 
     function ResOutputAvailable(aRes: TWareType; const aCount: Word): Boolean; override;
     function CanEquip(aUnitType: TUnitType): Boolean;
@@ -275,6 +276,13 @@ begin
     RecruitsAdd(U);
     gHands[fOwner].Stats.UnitCreated(ut_Recruit, False);
   end;
+end;
+
+
+procedure TKMHouseBarracks.ValidateNUpdateRallyPoint;
+begin
+  //this will automatically update rally point to valid value
+  SetRallyPoint(fRallyPoint);
 end;
 
 

--- a/src/houses/KM_Houses.pas
+++ b/src/houses/KM_Houses.pas
@@ -466,10 +466,8 @@ procedure TKMHouse.SetPosition(aPos: TKMPoint);
     end
     else if (Self is TKMHouseWoodcutters) then
     begin
-      if not aIsRallyPointSet then
-        TKMHouseWoodcutters(Self).CuttingPoint := PointBelowEntrance
-      else
-        TKMHouseWoodcutters(Self).ValidateNUpdateCuttingPoint;
+      //reset cutting point, because it has max distance limit
+      TKMHouseWoodcutters(Self).CuttingPoint := PointBelowEntrance
     end;
   end;
 var

--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -371,7 +371,6 @@ var
   C: TKMHouseWoodcutters;
   P: TKMPointF;
 begin
-  if gGame.IsMapEditor then Exit; // Don't render rally point in map editor
   if not (gMySpectator.Selected is TKMHouseBarracks) and not (gMySpectator.Selected is TKMHouseWoodcutters) then
     Exit;
 


### PR DESCRIPTION
Points can be set via 2 ways:
1. By clicking on button in house menu, then cursor changes to kmc_Beacon (do we need special cursor for this small feature?), then with left mouse button click on the map.
2. by clicking Shift + right mouse button on the map, when house (barracks/woodcutters) is selected. Its faster and also using right mouse button is more natural, because of using same button for this in the game.