### PR TITLE
BugFix: MapEd: update state of marker buttons on right click

### DIFF
--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -4947,7 +4947,6 @@ end;
 
 
 procedure TKMColumnBox.MouseDown(X,Y: Integer; Shift: TShiftState; Button: TMouseButton);
-var IsMouseDownHandled: Boolean;
 begin
   inherited;
   MouseMove(X, Y, Shift);

--- a/src/gui/KM_InterfaceMapEditor.pas
+++ b/src/gui/KM_InterfaceMapEditor.pas
@@ -61,6 +61,7 @@ type
     procedure ShowMarkerInfo(aMarker: TKMMapEdMarker);
     procedure Player_SetActive(aIndex: TKMHandIndex);
     procedure Player_UpdatePages;
+    procedure UpdateStateInternal;
     procedure UpdatePlayerSelectButtons;
   protected
     MinimapView: TKMMinimapView;
@@ -93,6 +94,7 @@ type
 
     procedure SyncUI(aMoveViewport: Boolean = True); override;
     procedure UpdateState(aTickCount: Cardinal); override;
+    procedure UpdateStateImmidiately;
     procedure UpdateStateIdle(aFrameTime: Cardinal); override;
     procedure Paint; override;
   end;
@@ -334,9 +336,25 @@ begin
   //Show players without assets in grey
   if aTickCount mod 10 = 0 then
     UpdatePlayerSelectButtons;
-                 
+
+  UpdateStateInternal;
+end;
+
+
+procedure TKMapEdInterface.UpdateStateInternal;
+begin
   fGuiTerrain.UpdateState;
   fGuiMenu.UpdateState;
+  fGuiTown.UpdateState;
+  fGuiPlayer.UpdateState;
+end;
+
+
+procedure TKMapEdInterface.UpdateStateImmidiately;
+begin
+  fMinimap.Update(False);
+  UpdatePlayerSelectButtons;
+  UpdateStateInternal;
 end;
 
 
@@ -713,7 +731,10 @@ begin
   end;
 
   if Button = mbRight then
+  begin
     RightClick_Cancel;
+    UpdateStateImmidiately;
+  end;
 
   //So terrain brushes start on mouse down not mouse move
   UpdateGameCursor(X, Y, Shift);

--- a/src/gui/KM_InterfaceMapEditor.pas
+++ b/src/gui/KM_InterfaceMapEditor.pas
@@ -198,8 +198,8 @@ begin
   fGuiGoal := TKMMapEdGoal.Create(Panel_Main);
 
   //Pass pop-ups to their dispatchers
-  fGuiTown.fGuiDefence.FormationsPopUp := fGuiFormations;
-  fGuiTown.fGuiOffence.AttackPopUp := fGuiAttack;
+  fGuiTown.GuiDefence.FormationsPopUp := fGuiFormations;
+  fGuiTown.GuiOffence.AttackPopUp := fGuiAttack;
   fGuiPlayer.fGuiPlayerGoals.GoalPopUp := fGuiGoal;
 
   //Hints go above everything

--- a/src/gui/pages_maped/KM_GUIMapEdPlayer.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdPlayer.pas
@@ -39,6 +39,7 @@ type
     function Visible: Boolean; overload;
     procedure ChangePlayer;
     procedure UpdatePlayerColor;
+    procedure UpdateState;
   end;
 
 
@@ -201,6 +202,12 @@ begin
 
   fGuiPlayerView.UpdatePlayerColor;
   fGuiPlayerBlockUnit.UpdatePlayerColor;
+end;
+
+
+procedure TKMMapEdPlayer.UpdateState;
+begin
+  fGuiPlayerView.UpdateState;
 end;
 
 

--- a/src/gui/pages_maped/KM_GUIMapEdPlayerView.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdPlayerView.pas
@@ -23,6 +23,7 @@ type
     procedure Show;
     function Visible: Boolean;
     procedure Hide;
+    procedure UpdateState;
     procedure UpdatePlayerColor;
   end;
 
@@ -105,6 +106,13 @@ begin
     gGame.ActiveInterface.Viewport.Position := KMPointF(gMySpectator.Hand.CenterScreen); //Jump to location
 
   Button_PlayerCenterScreen.Caption := TypeToString(gMySpectator.Hand.CenterScreen);
+end;
+
+
+procedure TKMMapEdPlayerView.UpdateState;
+begin
+  Button_CenterScreen.Down := (gGameCursor.Mode = cmMarkers) and (gGameCursor.Tag1 = MARKER_CENTERSCREEN);
+  Button_Reveal.Down := (gGameCursor.Mode = cmMarkers) and (gGameCursor.Tag1 = MARKER_REVEAL);
 end;
 
 

--- a/src/gui/pages_maped/KM_GUIMapEdTerrain.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdTerrain.pas
@@ -195,7 +195,9 @@ end;
 
 procedure TKMMapEdTerrain.UpdateState;
 begin
+  fGuiBrushes.UpdateState;
   fGuiTiles.UpdateState;
+  fGuiObjects.UpdateState;
   fGuiSelection.UpdateState;
 
   Button_TerrainUndo.Enabled := gGame.MapEditor.TerrainPainter.CanUndo;

--- a/src/gui/pages_maped/KM_GUIMapEdTerrainBrushes.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdTerrainBrushes.pas
@@ -25,6 +25,7 @@ type
     procedure Show;
     procedure Hide;
     function Visible: Boolean;
+    procedure UpdateState;
   end;
 
 
@@ -127,6 +128,12 @@ end;
 function TKMMapEdTerrainBrushes.Visible: Boolean;
 begin
   Result := Panel_Brushes.Visible;
+end;
+
+
+procedure TKMMapEdTerrainBrushes.UpdateState;
+begin
+  BrushRefresh;
 end;
 
 

--- a/src/gui/pages_maped/KM_GUIMapEdTerrainObjects.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdTerrainObjects.pas
@@ -30,6 +30,7 @@ type
     procedure Show;
     function Visible: Boolean;
     procedure Hide;
+    procedure UpdateState;
   end;
 
 
@@ -143,7 +144,7 @@ begin
       ObjectsTable[I].Disable;
     end;
     //Mark the selected one using reverse lookup
-    ObjectsTable[I].Down := (gGameCursor.Mode = cmObjects) and (ObjID = fMapElemToCompact[gGameCursor.Tag1]);
+    ObjectsTable[I].Down := (gGameCursor.Mode = cmObjects) and not (gGameCursor.Tag1 in [255, 61]) and (ObjID = fMapElemToCompact[gGameCursor.Tag1]);
   end;
 
   ObjectErase.Down := (gGameCursor.Mode = cmObjects) and (gGameCursor.Tag1 = 255); //or delete button
@@ -171,6 +172,12 @@ end;
 procedure TKMMapEdTerrainObjects.Hide;
 begin
   Panel_Objects.Hide;
+end;
+
+
+procedure TKMMapEdTerrainObjects.UpdateState;
+begin
+  ObjectsRefresh(nil);
 end;
 
 

--- a/src/gui/pages_maped/KM_GUIMapEdTerrainTiles.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdTerrainTiles.pas
@@ -147,6 +147,7 @@ var
   TileID: Integer;
 begin
   TilesRandom.Checked := (gGameCursor.MapEdDir = 4);
+  TilesEyedropper.Down := gGameCursor.Mode = cmEyedropper;
 
   for I := 0 to MAPED_TILES_Y - 1 do
   for K := 0 to MAPED_TILES_X - 1 do
@@ -164,7 +165,6 @@ begin
       TilesTable[L].Hint := IntToStr(TileID - 1);
     //If cursor has a tile then make sure its properly selected in table as well
     TilesTable[L].Down := (gGameCursor.Mode = cmTiles) and (gGameCursor.Tag1 = TileID - 1);
-    TilesEyedropper.Down := gGameCursor.Mode = cmEyedropper;
   end;
 end;
 
@@ -191,7 +191,6 @@ end;
 
 procedure TKMMapEdTerrainTiles.UpdateState;
 begin
-  TilesRandom.Checked := (gGameCursor.MapEdDir = 4);
   TilesRefresh(nil);
 end;
 

--- a/src/gui/pages_maped/KM_GUIMapEdTown.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdTown.pas
@@ -20,16 +20,19 @@ type
     fGuiHouses: TKMMapEdTownHouses;
     fGuiUnits: TKMMapEdTownUnits;
     fGuiScript: TKMMapEdTownScript;
+    fGuiDefence: TKMMapEdTownDefence;
+    fGuiOffence: TKMMapEdTownOffence;
 
     procedure PageChange(Sender: TObject);
   protected
     Panel_Town: TKMPanel;
     Button_Town: array [TKMTownTab] of TKMButton;
   public
-    fGuiDefence: TKMMapEdTownDefence;
-    fGuiOffence: TKMMapEdTownOffence;
     constructor Create(aParent: TKMPanel; aOnPageChange: TNotifyEvent);
     destructor Destroy; override;
+
+    property GuiDefence: TKMMapEdTownDefence read fGuiDefence;
+    property GuiOffence: TKMMapEdTownOffence read fGuiOffence;
 
     procedure Show(aPage: TKMTownTab);
     procedure ShowIndex(aIndex: Byte);

--- a/src/gui/pages_maped/KM_GUIMapEdTown.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdTown.pas
@@ -37,6 +37,7 @@ type
     function Visible: Boolean; overload;
     procedure ChangePlayer;
     procedure UpdatePlayerColor;
+    procedure UpdateState;
   end;
 
 
@@ -196,6 +197,13 @@ begin
   //Update colors
   Button_Town[ttUnits].FlagColor := gMySpectator.Hand.FlagColor;
   fGuiUnits.UpdatePlayerColor;
+end;
+
+
+procedure TKMMapEdTown.UpdateState;
+begin
+  fGuiScript.UpdateState;
+  fGuiDefence.UpdateState;
 end;
 
 

--- a/src/gui/pages_maped/KM_GUIMapEdTown.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdTown.pas
@@ -205,6 +205,8 @@ end;
 
 procedure TKMMapEdTown.UpdateState;
 begin
+  fGuiHouses.UpdateState;
+  fGuiUnits.UpdateState;
   fGuiScript.UpdateState;
   fGuiDefence.UpdateState;
 end;

--- a/src/gui/pages_maped/KM_GUIMapEdTownDefence.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdTownDefence.pas
@@ -32,6 +32,7 @@ type
     procedure Show;
     procedure Hide;
     function Visible: Boolean;
+    procedure UpdateState;
   end;
 
 
@@ -163,6 +164,12 @@ end;
 function TKMMapEdTownDefence.Visible: Boolean;
 begin
   Result := Panel_Defence.Visible;
+end;
+
+
+procedure TKMMapEdTownDefence.UpdateState;
+begin
+  Button_DefencePosAdd.Down := (gGameCursor.Mode = cmMarkers) and (gGameCursor.Tag1 = MARKER_DEFENCE);
 end;
 
 

--- a/src/gui/pages_maped/KM_GUIMapEdTownHouses.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdTownHouses.pas
@@ -23,6 +23,7 @@ type
     procedure Show;
     procedure Hide;
     function Visible: Boolean;
+    procedure UpdateState;
   end;
 
 
@@ -127,6 +128,12 @@ end;
 function TKMMapEdTownHouses.Visible: Boolean;
 begin
   Result := Panel_Build.Visible;
+end;
+
+
+procedure TKMMapEdTownHouses.UpdateState;
+begin
+  Town_BuildRefresh;
 end;
 
 

--- a/src/gui/pages_maped/KM_GUIMapEdTownScript.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdTownScript.pas
@@ -27,6 +27,7 @@ type
     procedure Show;
     procedure Hide;
     function Visible: Boolean;
+    procedure UpdateState;
   end;
 
 
@@ -135,6 +136,12 @@ begin
     gGameCursor.Mode := cmNone;
     gGameCursor.Tag1 := 0;
   end;
+end;
+
+
+procedure TKMMapEdTownScript.UpdateState;
+begin
+  Button_AIStart.Down := (gGameCursor.Mode = cmMarkers) and (gGameCursor.Tag1 = MARKER_AISTART);
 end;
 
 

--- a/src/gui/pages_maped/KM_GUIMapEdTownUnits.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdTownUnits.pas
@@ -23,6 +23,7 @@ type
     procedure Hide;
     function Visible: Boolean;
     procedure UpdatePlayerColor;
+    procedure UpdateState;
   end;
 
 
@@ -118,6 +119,12 @@ end;
 function TKMMapEdTownUnits.Visible: Boolean;
 begin
   Result := Panel_Units.Visible;
+end;
+
+
+procedure TKMMapEdTownUnits.UpdateState;
+begin
+  Town_UnitRefresh;
 end;
 
 

--- a/src/hands/KM_HandsCollection.pas
+++ b/src/hands/KM_HandsCollection.pas
@@ -286,7 +286,7 @@ begin
       H := fHandsList[I].Houses[K];
       if (H is TKMHouseTower) and H.IsComplete
       and not H.IsDestroyed and H.GetHasOwner
-      and (H.fCurrentAction.State <> hst_Empty) then
+      and (H.CurrentAction.State <> hst_Empty) then
         //Don't use H.GetDistance (dist to any tile within house) as that's not how tower range works
         Result := Min(Result, KMLength(H.GetPosition, aLoc));
     end;

--- a/src/houses/KM_HouseSchool.pas
+++ b/src/houses/KM_HouseSchool.pas
@@ -254,11 +254,11 @@ begin
     Result := 0
   else
     Result := (
-              Byte(ha_Work2 in fCurrentAction.SubAction) * 30 +
-              Byte(ha_Work3 in fCurrentAction.SubAction) * 60 +
-              Byte(ha_Work4 in fCurrentAction.SubAction) * 90 +
-              Byte(ha_Work5 in fCurrentAction.SubAction) * 120 +
-              Byte(fCurrentAction.State = hst_Work) * WorkAnimStep
+              Byte(ha_Work2 in CurrentAction.SubAction) * 30 +
+              Byte(ha_Work3 in CurrentAction.SubAction) * 60 +
+              Byte(ha_Work4 in CurrentAction.SubAction) * 90 +
+              Byte(ha_Work5 in CurrentAction.SubAction) * 120 +
+              Byte(CurrentAction.State = hst_Work) * WorkAnimStep
               ) / 150;
 end;
 

--- a/src/houses/KM_Houses.pas
+++ b/src/houses/KM_Houses.pas
@@ -84,7 +84,7 @@ type
     procedure SetBuildingRepair(aValue: Boolean);
     procedure SetResOrder(aId: Byte; aValue: Integer); virtual;
   public
-    fCurrentAction: THouseAction; //Current action, withing HouseTask or idle
+    CurrentAction: THouseAction; //Current action, withing HouseTask or idle
     ResourceDepletedMsgIssued: Boolean;
     DoorwayUse: Byte; //number of units using our door way. Used for sliding.
     OnDestroyed: TKMHouseFromEvent;
@@ -322,8 +322,8 @@ begin
   LoadStream.Read(HasAct);
   if HasAct then
   begin
-    fCurrentAction := THouseAction.Create(nil, hst_Empty); //Create action object
-    fCurrentAction.Load(LoadStream); //Load actual data into object
+    CurrentAction := THouseAction.Create(nil, hst_Empty); //Create action object
+    CurrentAction.Load(LoadStream); //Load actual data into object
   end;
   LoadStream.Read(ResourceDepletedMsgIssued);
   LoadStream.Read(DoorwayUse);
@@ -332,14 +332,14 @@ end;
 
 procedure TKMHouse.SyncLoad;
 begin
-  if fCurrentAction <> nil then
-    fCurrentAction.fHouse := gHands.GetHouseByUID(Cardinal(fCurrentAction.fHouse));
+  if CurrentAction <> nil then
+    CurrentAction.fHouse := gHands.GetHouseByUID(Cardinal(CurrentAction.fHouse));
 end;
 
 
 destructor TKMHouse.Destroy;
 begin
-  FreeAndNil(fCurrentAction);
+  FreeAndNil(CurrentAction);
   inherited;
 end;
 
@@ -370,8 +370,8 @@ begin
 
   gHands.RevealForTeam(fOwner, fPosition, gRes.Houses[fHouseType].Sight, FOG_OF_WAR_MAX);
 
-  fCurrentAction := THouseAction.Create(Self, hst_Empty);
-  fCurrentAction.SubActionAdd([ha_Flagpole, ha_Flag1..ha_Flag3]);
+  CurrentAction := THouseAction.Create(Self, hst_Empty);
+  CurrentAction.SubActionAdd([ha_Flagpole, ha_Flag1..ha_Flag3]);
 
   UpdateDamage; //House might have been damaged during construction, so show flames when it is built
 
@@ -443,7 +443,7 @@ begin
     end;
   end;
 
-  FreeAndNil(fCurrentAction);
+  FreeAndNil(CurrentAction);
 
   //Leave disposing of units inside the house to themselves
 
@@ -738,15 +738,15 @@ var
   dmgLevel: Word;
 begin
   dmgLevel := MaxHealth div 8; //There are 8 fire places for each house, so the increment for each fire level is Max_Health / 8
-  fCurrentAction.SubActionRem([ha_Fire1, ha_Fire2, ha_Fire3, ha_Fire4, ha_Fire5, ha_Fire6, ha_Fire7, ha_Fire8]);
-  if fDamage > 0 * dmgLevel then fCurrentAction.SubActionAdd([ha_Fire1]);
-  if fDamage > 1 * dmgLevel then fCurrentAction.SubActionAdd([ha_Fire2]);
-  if fDamage > 2 * dmgLevel then fCurrentAction.SubActionAdd([ha_Fire3]);
-  if fDamage > 3 * dmgLevel then fCurrentAction.SubActionAdd([ha_Fire4]);
-  if fDamage > 4 * dmgLevel then fCurrentAction.SubActionAdd([ha_Fire5]);
-  if fDamage > 5 * dmgLevel then fCurrentAction.SubActionAdd([ha_Fire6]);
-  if fDamage > 6 * dmgLevel then fCurrentAction.SubActionAdd([ha_Fire7]);
-  if fDamage > 7 * dmgLevel then fCurrentAction.SubActionAdd([ha_Fire8]);
+  CurrentAction.SubActionRem([ha_Fire1, ha_Fire2, ha_Fire3, ha_Fire4, ha_Fire5, ha_Fire6, ha_Fire7, ha_Fire8]);
+  if fDamage > 0 * dmgLevel then CurrentAction.SubActionAdd([ha_Fire1]);
+  if fDamage > 1 * dmgLevel then CurrentAction.SubActionAdd([ha_Fire2]);
+  if fDamage > 2 * dmgLevel then CurrentAction.SubActionAdd([ha_Fire3]);
+  if fDamage > 3 * dmgLevel then CurrentAction.SubActionAdd([ha_Fire4]);
+  if fDamage > 4 * dmgLevel then CurrentAction.SubActionAdd([ha_Fire5]);
+  if fDamage > 5 * dmgLevel then CurrentAction.SubActionAdd([ha_Fire6]);
+  if fDamage > 6 * dmgLevel then CurrentAction.SubActionAdd([ha_Fire7]);
+  if fDamage > 7 * dmgLevel then CurrentAction.SubActionAdd([ha_Fire8]);
   //House gets destroyed in UpdateState loop
 end;
 
@@ -788,13 +788,13 @@ end;
 
 procedure TKMHouse.SetState(aState: THouseState);
 begin
-  fCurrentAction.State := aState;
+  CurrentAction.State := aState;
 end;
 
 
 function TKMHouse.GetState: THouseState;
 begin
-  Result := fCurrentAction.State;
+  Result := CurrentAction.State;
 end;
 
 
@@ -1144,13 +1144,13 @@ var
 begin
   if SKIP_SOUND then Exit;
 
-  if fCurrentAction = nil then exit; //no action means no sound ;)
+  if CurrentAction = nil then exit; //no action means no sound ;)
 
-  if ha_Work1 in fCurrentAction.SubAction then Work := ha_Work1 else
-  if ha_Work2 in fCurrentAction.SubAction then Work := ha_Work2 else
-  if ha_Work3 in fCurrentAction.SubAction then Work := ha_Work3 else
-  if ha_Work4 in fCurrentAction.SubAction then Work := ha_Work4 else
-  if ha_Work5 in fCurrentAction.SubAction then Work := ha_Work5 else
+  if ha_Work1 in CurrentAction.SubAction then Work := ha_Work1 else
+  if ha_Work2 in CurrentAction.SubAction then Work := ha_Work2 else
+  if ha_Work3 in CurrentAction.SubAction then Work := ha_Work3 else
+  if ha_Work4 in CurrentAction.SubAction then Work := ha_Work4 else
+  if ha_Work5 in CurrentAction.SubAction then Work := ha_Work5 else
     Exit; //No work is going on
 
   Step := gRes.Houses[fHouseType].Anim[Work].Count;
@@ -1241,9 +1241,9 @@ begin
   SaveStream.Write(fDisableUnoccupiedMessage);
   SaveStream.Write(fIssueOrderCompletedMsg);
   SaveStream.Write(fUID);
-  HasAct := fCurrentAction <> nil;
+  HasAct := CurrentAction <> nil;
   SaveStream.Write(HasAct);
-  if HasAct then fCurrentAction.Save(SaveStream);
+  if HasAct then CurrentAction.Save(SaveStream);
   SaveStream.Write(ResourceDepletedMsgIssued);
   SaveStream.Write(DoorwayUse);
 end;
@@ -1371,8 +1371,8 @@ begin
                     else
                       fRenderPool.AddHouse(fHouseType, fPosition, 1, 1, 0);
                     fRenderPool.AddHouseSupply(fHouseType, fPosition, fResourceIn, fResourceOut);
-                    if fCurrentAction <> nil then
-                      fRenderPool.AddHouseWork(fHouseType, fPosition, fCurrentAction.SubAction, WorkAnimStep, gHands[fOwner].FlagColor);
+                    if CurrentAction <> nil then
+                      fRenderPool.AddHouseWork(fHouseType, fPosition, CurrentAction.SubAction, WorkAnimStep, gHands[fOwner].FlagColor);
                   end
                   else
                     fRenderPool.AddHouse(fHouseType, fPosition,
@@ -1454,9 +1454,9 @@ begin
         fRenderPool.AddHouseStableBeasts(fHouseType, fPosition, I, Min(BeastAge[I],3), WorkAnimStep);
 
   //But Animal Breeders should be on top of beasts
-  if fCurrentAction <> nil then
+  if CurrentAction <> nil then
     fRenderPool.AddHouseWork(fHouseType, fPosition,
-                            fCurrentAction.SubAction * [ha_Work1, ha_Work2, ha_Work3, ha_Work4, ha_Work5],
+                            CurrentAction.SubAction * [ha_Work1, ha_Work2, ha_Work3, ha_Work4, ha_Work5],
                             WorkAnimStep, gHands[fOwner].FlagColor);
 end;
 

--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -1398,7 +1398,7 @@ begin
     cmMarkers:    case gGameCursor.Tag1 of
                     MARKER_REVEAL:        begin
                                             RenderSpriteOnTile(P, 394, gMySpectator.Hand.FlagColor);
-                                            gRenderAux.CircleOnTerrain(P.X, P.Y,
+                                            gRenderAux.CircleOnTerrain(P.X-0.5, P.Y-0.5,
                                              gGameCursor.MapEdSize,
                                              gMySpectator.Hand.FlagColor AND $10FFFFFF,
                                              gMySpectator.Hand.FlagColor);

--- a/src/units/KM_UnitActionGoInOut.pas
+++ b/src/units/KM_UnitActionGoInOut.pas
@@ -368,7 +368,7 @@ begin
       and (fUnit.GetHome <> nil)
       and (fUnit.GetHome.HouseType = ht_Woodcutters)
       and (fUnit.GetHome = fHouse) then //And is the house we are walking from
-        fHouse.fCurrentAction.SubActionAdd([ha_Flagpole]);
+        fHouse.CurrentAction.SubActionAdd([ha_Flagpole]);
 
       if Assigned(OnWalkedIn) then
         OnWalkedIn;

--- a/src/units/KM_UnitTaskMining.pas
+++ b/src/units/KM_UnitTaskMining.pas
@@ -231,7 +231,7 @@ begin
 
           //Woodcutter takes his axe with him when going to chop trees
           if (WorkPlan.GatheringScript = gs_WoodCutterCut) then
-            GetHome.fCurrentAction.SubActionRem([ha_Flagpole]);
+            GetHome.CurrentAction.SubActionRem([ha_Flagpole]);
         end
         else
         begin
@@ -321,7 +321,7 @@ begin
             gHands[fUnit.Owner].Stats.WareConsumed(WorkPlan.Resource1, WorkPlan.Count1);
             gHands[fUnit.Owner].Stats.WareConsumed(WorkPlan.Resource2, WorkPlan.Count2);
 
-            GetHome.fCurrentAction.SubActionAdd([ha_Smoke]);
+            GetHome.CurrentAction.SubActionAdd([ha_Smoke]);
             if WorkPlan.GatheringScript = gs_SwineBreeder then
             begin //Swines get feed and taken immediately
               fBeastID := TKMHouseSwineStable(GetHome).FeedBeasts;
@@ -330,7 +330,7 @@ begin
 
             if WorkPlan.ActCount >= fPhase2 then
             begin
-              GetHome.fCurrentAction.SubActionWork(WorkPlan.HouseAct[fPhase2].Act);
+              GetHome.CurrentAction.SubActionWork(WorkPlan.HouseAct[fPhase2].Act);
               //Keep unit idling till next Phase, Idle time is -1 to compensate TaskExecution Phase
               SetActionLockedStay(WorkPlan.HouseAct[fPhase2].TimeToWork-1, ua_Walk);
             end
@@ -352,7 +352,7 @@ begin
             //Keep on working
             if fPhase2 <= WorkPlan.ActCount then
             begin
-              GetHome.fCurrentAction.SubActionWork(WorkPlan.HouseAct[fPhase2].Act);
+              GetHome.CurrentAction.SubActionWork(WorkPlan.HouseAct[fPhase2].Act);
               if fPhase < WorkPlan.ActCount then
                 SetActionLockedStay(WorkPlan.HouseAct[fPhase2].TimeToWork-1, ua_Walk) //-1 to compensate units UpdateState run
               else

--- a/src/units/KM_UnitTaskSelfTrain.pas
+++ b/src/units/KM_UnitTaskSelfTrain.pas
@@ -79,23 +79,23 @@ begin
     case fPhase of
       0: begin
           fSchool.SetState(hst_Work);
-          fSchool.fCurrentAction.SubActionWork(ha_Work1);
+          fSchool.CurrentAction.SubActionWork(ha_Work1);
           SetActionLockedStay(29, ua_Walk);
         end;
       1: begin
-          fSchool.fCurrentAction.SubActionWork(ha_Work2);
+          fSchool.CurrentAction.SubActionWork(ha_Work2);
           SetActionLockedStay(29, ua_Walk);
         end;
       2: begin
-          fSchool.fCurrentAction.SubActionWork(ha_Work3);
+          fSchool.CurrentAction.SubActionWork(ha_Work3);
           SetActionLockedStay(29, ua_Walk);
         end;
       3: begin
-          fSchool.fCurrentAction.SubActionWork(ha_Work4);
+          fSchool.CurrentAction.SubActionWork(ha_Work4);
           SetActionLockedStay(29, ua_Walk);
         end;
       4: begin
-          fSchool.fCurrentAction.SubActionWork(ha_Work5);
+          fSchool.CurrentAction.SubActionWork(ha_Work5);
           SetActionLockedStay(29, ua_Walk);
         end;
       5: begin

--- a/src/units/KM_UnitTaskThrowRock.pas
+++ b/src/units/KM_UnitTaskThrowRock.pas
@@ -75,7 +75,7 @@ begin
   case fPhase of
     0:  begin
           GetHome.SetState(hst_Work); //Set house to Work state
-          GetHome.fCurrentAction.SubActionWork(ha_Work2); //show Recruits back
+          GetHome.CurrentAction.SubActionWork(ha_Work2); //show Recruits back
           SetActionStay(2, ua_Walk); //pretend to be taking the stone
         end;
     1:  begin


### PR DESCRIPTION
Bug description from Ben on 
[kam.net](http://www.knightsandmerchants.net/forum/viewtopic.php?f=23&t=3206)

Also fixed:
when placing units/houses/roads/fields/tile brushes/tile objects - after RBM click they are still selected, even if you can't use them actually.

Also this visual bug with reveal circle fixed:

![reveal circle bug](https://puu.sh/tUOGX/f9ecc2f4be.png)

Also some small refactoring here:

public TKMHouse.fCurrentAction -> TKMHouse.CurrentAction

TKMMapEdTown
public     
    fGuiDefence: TKMMapEdTownDefence; 
    fGuiOffence: TKMMapEdTownOffence; 

private 
    fGuiDefence: TKMMapEdTownDefence;
    fGuiOffence: TKMMapEdTownOffence;
public 
    property GuiDefence: TKMMapEdTownDefence read fGuiDefence;
    property GuiOffence: TKMMapEdTownOffence read fGuiOffence;