### PR TITLE
Fix: Rally/Cutting point: do not update in Getter, update manually when they used

### DIFF
--- a/src/KM_MapEditor.pas
+++ b/src/KM_MapEditor.pas
@@ -323,9 +323,9 @@ begin
                                                       end;
                                 MARKER_AISTART:       gMySpectator.Hand.AI.Setup.StartPosition := P;
                                 MARKER_RALLY_POINT:   if gMySpectator.Selected is TKMHouseBarracks then
-                                                        TKMHouseBarracks(gMySpectator.Selected).RallyPoint := gGameCursor.Cell;
+                                                        TKMHouseBarracks(gMySpectator.Selected).RallyPoint := P;
                                 MARKER_CUTTING_POINT: if gMySpectator.Selected is TKMHouseWoodcutters then
-                                                        TKMHouseWoodcutters(gMySpectator.Selected).CuttingPoint := gGameCursor.Cell;
+                                                        TKMHouseWoodcutters(gMySpectator.Selected).CuttingPoint := P;
                               end;
                 cmErase:      begin
                                 gHands.RemAnyHouse(P);

--- a/src/hands/KM_Hand.pas
+++ b/src/hands/KM_Hand.pas
@@ -390,7 +390,9 @@ end;
 
 
 procedure TKMHand.WarriorWalkedOut(aUnit: TKMUnitWarrior);
-var G: TKMUnitGroup; H: TKMHouse;
+var G: TKMUnitGroup;
+    H: TKMHouse;
+    B: TKMHouseBarracks;
 begin
   //Warrior could be killed before he walked out, f.e. by script OnTick ---> Actions.UnitKill
   //Then group will be assigned to invalid warrior and never gets removed from game
@@ -410,9 +412,14 @@ begin
     begin
       //If player is human and this is the first warrior in the group, send it to the rally point
       H := HousesHitTest(aUnit.GetPosition.X, aUnit.GetPosition.Y-1);
-      if (H is TKMHouseBarracks) and TKMHouseBarracks(H).IsRallyPointSet
-      and G.CanWalkTo(TKMHouseBarracks(H).RallyPoint, 0) then
-        G.OrderWalk(TKMHouseBarracks(H).RallyPoint, True);
+      if (H is TKMHouseBarracks) then
+      begin
+        B := TKMHouseBarracks(H);
+        B.ValidateRallyPoint; // Validate Rally point first. It will set it to a proper walkable position
+        if B.IsRallyPointSet
+          and G.CanWalkTo(B.RallyPoint, 0) then
+          G.OrderWalk(B.RallyPoint, True);
+      end;
     end;
   gScriptEvents.ProcWarriorEquipped(aUnit, G);
 end;

--- a/src/houses/KM_HouseBarracks.pas
+++ b/src/houses/KM_HouseBarracks.pas
@@ -14,7 +14,6 @@ type
     fRecruitsList: TList;
     fResourceCount: array [WARFARE_MIN..WARFARE_MAX] of Word;
     fRallyPoint: TKMPoint;
-    function GetRallyPoint: TKMPoint;
     procedure SetRallyPoint(aRallyPoint: TKMPoint);
     function GetRallyPointTexId: Word;
   public
@@ -33,7 +32,8 @@ type
     function CheckResIn(aWare: TWareType): Word; override;
     function ResCanAddToIn(aRes: TWareType): Boolean; override;
 
-    property RallyPoint: TKMPoint read GetRallyPoint write SetRallyPoint;
+    property RallyPoint: TKMPoint read fRallyPoint write SetRallyPoint;
+    function IsRallyPointSet: Boolean;
     procedure ValidateRallyPoint;
 
     function ResOutputAvailable(aRes: TWareType; const aCount: Word): Boolean; override;
@@ -42,7 +42,6 @@ type
     procedure RecruitsAdd(aUnit: Pointer);
     procedure RecruitsRemove(aUnit: Pointer);
     procedure ToggleAcceptFlag(aRes: TWareType);
-    function IsRallyPointSet: Boolean;
     function Equip(aUnitType: TUnitType; aCount: Byte): Byte;
     procedure CreateRecruitInside(aIsMapEd: Boolean);
 
@@ -212,7 +211,7 @@ end;
 
 function TKMHouseBarracks.IsRallyPointSet: Boolean;
 begin
-   Result := not KMSamePoint(RallyPoint, PointBelowEntrance); //Use RallyPoint, not fRallyPoint to be sure its Valid
+   Result := not KMSamePoint(fRallyPoint, PointBelowEntrance);
 end;
 
 
@@ -298,15 +297,6 @@ end;
 procedure TKMHouseBarracks.SetRallyPoint(aRallyPoint: TKMPoint);
 begin
   fRallyPoint := gTerrain.GetPassablePointWithinSegment(PointBelowEntrance, aRallyPoint, tpWalk);
-end;
-
-
-function TKMHouseBarracks.GetRallyPoint: TKMPoint;
-begin
-  if not gTerrain.CheckPassability(fRallyPoint, tpWalk) then
-    //update rally point if its not valid (not walkable). Set it closer to barracks entrance (PointBelowEntrance)
-    SetRallyPoint(fRallyPoint);
-  Result := fRallyPoint;
 end;
 
 

--- a/src/houses/KM_Houses.pas
+++ b/src/houses/KM_Houses.pas
@@ -217,18 +217,17 @@ type
     fCuttingPoint: TKMPoint;
     procedure SetWoodcutterMode(aWoodcutterMode: TWoodcutterMode);
     procedure SetCuttingPoint(aValue: TKMPoint);
-    function GetCuttingPoint: TKMPoint;
     function GetCuttingPointTexId: Word;
   public
     property WoodcutterMode: TWoodcutterMode read fWoodcutterMode write SetWoodcutterMode;
     constructor Create(aUID: Integer; aHouseType: THouseType; PosX, PosY: Integer; aOwner: TKMHandIndex; aBuildState: THouseBuildState);
     constructor Load(LoadStream: TKMemoryStream); override;
     procedure Save(SaveStream: TKMemoryStream); override;
+
     function IsCuttingPointSet: Boolean;
     procedure ValidateCuttingPoint;
-    property CuttingPoint: TKMPoint read GetCuttingPoint write SetCuttingPoint;
+    property CuttingPoint: TKMPoint read fCuttingPoint write SetCuttingPoint;
     function GetValidCuttingPoint(aPoint: TKMPoint): TKMPoint;
-
     property CuttingPointTexId: Word read GetCuttingPointTexId;
   end;
 
@@ -467,7 +466,7 @@ end;
 
 //Used by MapEditor
 procedure TKMHouse.SetPosition(aPos: TKMPoint);
-  procedure UpdateCuttingPoint(aIsRallyPointSet: Boolean);
+  procedure UpdateRallyPoint(aIsRallyPointSet: Boolean);
   begin
     if (Self is TKMHouseBarracks) then
     begin
@@ -502,7 +501,7 @@ begin
     fPosition.Y := aPos.Y;
 
     //Update rally/cutting point position for barracks/woodcutters after change fPosition
-    UpdateCuttingPoint(IsRallyPointSet);
+    UpdateRallyPoint(IsRallyPointSet);
   end;
   gTerrain.SetHouse(fPosition, fHouseType, hsBuilt, fOwner);
   gTerrain.SetField(Entrance, fOwner, ft_Road);
@@ -1704,7 +1703,7 @@ end;
 
 function TKMHouseWoodcutters.IsCuttingPointSet: Boolean;
 begin
-  Result := not KMSamePoint(CuttingPoint, PointBelowEntrance); //Use CuttingPoint, not fCuttingPoint to be sure its Valid
+  Result := not KMSamePoint(fCuttingPoint, PointBelowEntrance);
 end;
 
 
@@ -1712,15 +1711,6 @@ procedure TKMHouseWoodcutters.ValidateCuttingPoint;
 begin
   //this will automatically update cutting point to valid value
   SetCuttingPoint(fCuttingPoint);
-end;
-
-
-function TKMHouseWoodcutters.GetCuttingPoint: TKMPoint;
-begin
-  if not gTerrain.CheckPassability(fCuttingPoint, tpWalk) then
-    //Automatically update point to valid value (walkable, not more far then MAX_WOODCUTTER_CUT_PNT_DISTANCE)
-    SetCuttingPoint(fCuttingPoint);
-  Result := fCuttingPoint;
 end;
 
 

--- a/src/units/KM_Units_WorkPlan.pas
+++ b/src/units/KM_Units_WorkPlan.pas
@@ -237,6 +237,7 @@ begin
   case aUnit.UnitType of
     ut_Woodcutter:    if aHome = ht_Woodcutters then
                       begin
+                        TKMHouseWoodcutters(aUnit.GetHome).ValidateCuttingPoint; //Validate Cutting point. It will be set to a valid one if needed.
                         if TKMHouseWoodcutters(aUnit.GetHome).IsCuttingPointSet then
                           aLoc := TKMHouseWoodcutters(aUnit.GetHome).CuttingPoint;
                         fIssued := ChooseTree(aLoc, KMPoint(0,0), gRes.Units[aUnit.UnitType].MiningRange, aPlantAct, aUnit, Tmp, PlantAct);


### PR DESCRIPTION
Implementation of @lewinjh suggestion in #241:

> I suggest GetRallyPoint just returns fRallyPoint (so could be unwalkable), but then when you use the rally point (when soldier is trained or woodcutter goes to work) you call ValidateRallyPoint first. This will be from within the game code so safe for replays/MP.