### PR TITLE
Do not show owner of corn/wine tile + MapEd new layer: show tile owner

### DIFF
--- a/src/KM_Defaults.pas
+++ b/src/KM_Defaults.pas
@@ -595,7 +595,8 @@ type
     mlCenterScreen,
     mlAIStart,
     mlSelection,
-    mlWaterFlow);  //Enum representing mapEditor visible layers
+    mlWaterFlow,
+    mlTileOwner);  //Enum representing mapEditor visible layers
   TMapEdLayerSet = set of TMapEdLayer;                                   //Set of above enum
 
 const

--- a/src/KM_Minimap.pas
+++ b/src/KM_Minimap.pas
@@ -222,7 +222,9 @@ begin
     if FOW = 0 then
       fBase[I*fMapX + K] := $FF000000
     else
-      if fMyTerrain.Land[I+1,K+1].TileOwner <> -1 then
+      if (fMyTerrain.Land[I+1,K+1].TileOwner <> -1)
+        and not fMyTerrain.TileIsCornField(KMPoint(K+1, I+1)) //Do not show corn and wine on minimap
+        and not fMyTerrain.TileIsWineField(KMPoint(K+1, I+1)) then
         fBase[I*fMapX + K] := gHands[fMyTerrain.Land[I+1,K+1].TileOwner].FlagColor
       else
       begin

--- a/src/gui/KM_InterfaceMapEditor.pas
+++ b/src/gui/KM_InterfaceMapEditor.pas
@@ -443,6 +443,9 @@ begin
 
   if fGuiExtras.CheckBox_ShowDeposits.Checked then
     gGame.MapEditor.VisibleLayers := gGame.MapEditor.VisibleLayers + [mlDeposits];
+
+  if fGuiExtras.CheckBox_ShowTileOwners.Checked then
+    gGame.MapEditor.VisibleLayers := gGame.MapEditor.VisibleLayers + [mlTileOwner];
 end;
 
 

--- a/src/gui/pages_maped/KM_GUIMapEdExtras.pas
+++ b/src/gui/pages_maped/KM_GUIMapEdExtras.pas
@@ -23,6 +23,7 @@ type
     CheckBox_ShowHouses: TKMCheckBox;
     CheckBox_ShowUnits: TKMCheckBox;
     CheckBox_ShowDeposits: TKMCheckBox;
+    CheckBox_ShowTileOwners: TKMCheckBox;
     constructor Create(aParent: TKMPanel; aOnChange: TNotifyEvent);
 
     procedure Show;
@@ -81,6 +82,9 @@ begin
   CheckBox_ShowDeposits := TKMCheckBox.Create(Panel_Extra, 250, 130, 180, 20, gResTexts[TX_MAPED_VIEW_DEPOSISTS], fnt_Antiqua);
   CheckBox_ShowDeposits.Checked := True; //Enabled by default
   CheckBox_ShowDeposits.OnClick := Extra_Change;
+  CheckBox_ShowTileOwners := TKMCheckBox.Create(Panel_Extra, 250, 150, 180, 20, 'Show tile owners', fnt_Antiqua); //Todo translate
+  CheckBox_ShowTileOwners.Checked := False; //Disabled by default
+  CheckBox_ShowTileOwners.OnClick := Extra_Change;
 
   //dropdown list needs to be ontop other buttons created on Panel_Main
   Dropbox_PlayerFOW := TKMDropList.Create(Panel_Extra, 460, 70, 160, 20, fnt_Metal, '', bsGame);

--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -1229,7 +1229,7 @@ end;
 //P - tile coords
 //Col - Color
 //aInset - Internal adjustment, to render wire "inside" tile
-procedure TRenderPool.RenderWireTile(P: TKMPoint; Col: TColor4; aInset: Single = 0);
+procedure TRenderPool.RenderWireTile(P: TKMPoint; Col: TColor4; aInset: Single = 0.0);
 begin
   if not gTerrain.TileInMapCoords(P.X, P.Y) then exit;
   glColor4ubv(@Col);

--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -115,8 +115,7 @@ type
     procedure RenderSpriteOnTile(aLoc: TKMPoint; aId: Word; aFlagColor: TColor4 = $FFFFFFFF);
     procedure RenderSpriteOnTerrain(aLoc: TKMPointF; aId: Word; aFlagColor: TColor4 = $FFFFFFFF);
     procedure RenderTile(Index: Byte; pX,pY,Rot: Integer);
-    procedure RenderWireTile(P: TKMPoint; Col: TColor4); overload;
-    procedure RenderWireTile(P: TKMPoint; Col: TColor4; aInset: Single); overload;
+    procedure RenderWireTile(P: TKMPoint; Col: TColor4; aInset: Single = 0.0);
 
     property RenderList: TRenderList read fRenderList;
     property RenderTerrain: TRenderTerrain read fRenderTerrain;
@@ -1226,17 +1225,11 @@ begin
 end;
 
 
-procedure TRenderPool.RenderWireTile(P: TKMPoint; Col: TColor4);
-begin
-  RenderWireTile(P, Col, 0);
-end;
-
-
 //Render wire on tile
 //P - tile coords
 //Col - Color
 //aInset - Internal adjustment, to render wire "inside" tile
-procedure TRenderPool.RenderWireTile(P: TKMPoint; Col: TColor4; aInset: Single);
+procedure TRenderPool.RenderWireTile(P: TKMPoint; Col: TColor4; aInset: Single = 0);
 begin
   if not gTerrain.TileInMapCoords(P.X, P.Y) then exit;
   glColor4ubv(@Col);

--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -116,7 +116,7 @@ type
     procedure RenderSpriteOnTerrain(aLoc: TKMPointF; aId: Word; aFlagColor: TColor4 = $FFFFFFFF);
     procedure RenderTile(Index: Byte; pX,pY,Rot: Integer);
     procedure RenderWireTile(P: TKMPoint; Col: TColor4); overload;
-    procedure RenderWireTile(P: TKMPoint; Col: TColor4; PIntAdj: TKMPointF); overload;
+    procedure RenderWireTile(P: TKMPoint; Col: TColor4; aInset: Single); overload;
 
     property RenderList: TRenderList read fRenderList;
     property RenderTerrain: TRenderTerrain read fRenderTerrain;
@@ -1228,7 +1228,7 @@ end;
 
 procedure TRenderPool.RenderWireTile(P: TKMPoint; Col: TColor4);
 begin
-  RenderWireTile(P, Col, KMPointF(0, 0));
+  RenderWireTile(P, Col, 0);
 end;
 
 
@@ -1236,16 +1236,16 @@ end;
 //P - tile coords
 //Col - Color
 //PIntAdj - Internal adjustment, to render wire "inside" tile
-procedure TRenderPool.RenderWireTile(P: TKMPoint; Col: TColor4; PIntAdj: TKMPointF);
+procedure TRenderPool.RenderWireTile(P: TKMPoint; Col: TColor4; aInset: Single);
 begin
   if not gTerrain.TileInMapCoords(P.X, P.Y) then exit;
   glColor4ubv(@Col);
   glBegin(GL_LINE_LOOP);
     with gTerrain do begin
-      glVertex2f(P.X-1 + PIntAdj.X, P.Y-1 + PIntAdj.X - Land[P.Y  ,P.X  ].Height/CELL_HEIGHT_DIV);
-      glVertex2f(P.X   - PIntAdj.X, P.Y-1 + PIntAdj.X - Land[P.Y  ,P.X+1].Height/CELL_HEIGHT_DIV);
-      glVertex2f(P.X   - PIntAdj.X, P.Y   - PIntAdj.X - Land[P.Y+1,P.X+1].Height/CELL_HEIGHT_DIV);
-      glVertex2f(P.X-1 + PIntAdj.X, P.Y   - PIntAdj.X - Land[P.Y+1,P.X  ].Height/CELL_HEIGHT_DIV);
+      glVertex2f(P.X-1 + aInset, P.Y-1 + aInset - Land[P.Y  ,P.X  ].Height/CELL_HEIGHT_DIV);
+      glVertex2f(P.X   - aInset, P.Y-1 + aInset - Land[P.Y  ,P.X+1].Height/CELL_HEIGHT_DIV);
+      glVertex2f(P.X   - aInset, P.Y   - aInset - Land[P.Y+1,P.X+1].Height/CELL_HEIGHT_DIV);
+      glVertex2f(P.X-1 + aInset, P.Y   - aInset - Land[P.Y+1,P.X  ].Height/CELL_HEIGHT_DIV);
     end;
   glEnd;
 end;
@@ -1336,7 +1336,7 @@ begin
         and (gTerrain.TileIsCornField(P)                   // show only for corn + wine + roads
           or gTerrain.TileIsWineField(P)
           or (gTerrain.Land[I, K].TileOverlay = to_Road)) then
-        RenderWireTile(P, gHands[gTerrain.Land[I, K].TileOwner].FlagColor, KMPointF(0.05, 0.05));
+        RenderWireTile(P, gHands[gTerrain.Land[I, K].TileOwner].FlagColor, 0.05);
     end;
 end;
 

--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -1235,7 +1235,7 @@ end;
 //Render wire on tile
 //P - tile coords
 //Col - Color
-//PIntAdj - Internal adjustment, to render wire "inside" tile
+//aInset - Internal adjustment, to render wire "inside" tile
 procedure TRenderPool.RenderWireTile(P: TKMPoint; Col: TColor4; aInset: Single);
 begin
   if not gTerrain.TileInMapCoords(P.X, P.Y) then exit;

--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -1557,7 +1557,7 @@ begin
   if not IsRendered and
     (((gTerrain.Land[P.Y, P.X].TileOverlay = to_Road)
         and (gTerrain.Land[P.Y, P.X].TileLock = tlNone)) //Sometimes we can point road tile under the house, do not show Cyan quad then
-      or (gTerrain.Land[P.Y, P.X].CornOrWine <> 0)) //In future we are planning not to show color for corn/wine on minimap, but let it be for now
+      or (gTerrain.Land[P.Y, P.X].CornOrWine <> 0))
     and (gTerrain.Land[P.Y, P.X].TileOwner <> gMySpectator.HandIndex) then //Only if tile has other owner
     RenderWireTile(P, $FFFFFF00); // Cyan quad
 end;

--- a/src/terrain/KM_Terrain.pas
+++ b/src/terrain/KM_Terrain.pas
@@ -32,7 +32,7 @@ type
     TileLock: TTileLock;
 
     //Used to display half-dug road
-    TileOverlay: TTileOverlay; //fs_None fs_Dig1, fs_Dig2, fs_Dig3, fs_Dig4 +Roads
+    TileOverlay: TTileOverlay; //to_None to_Dig1, to_Dig2, to_Dig3, to_Dig4 + to_Road
 
     TileOwner: TKMHandIndex; //Who owns the tile by having a house/road/field on it
     IsUnit: Pointer; //Whenever there's a unit on that tile mark the tile as occupied and count the number


### PR DESCRIPTION
as we discussed in #243 and after some suggestions of @Kromster80 

1. Corn and wine do not show on minimap (maped and game)
2. But corn and wine tiles still has owner
3. To discover who is tile owner added new layer 'show tile owner' - like on the next screenshot

here how it looks like:
![tile owner](https://puu.sh/u6ge3/61c101ee62.png)