### PR TITLE
MapEd: add unit on mouse move with LMB. Fix issues with unit delete under cursor

### DIFF
--- a/src/KM_MapEditor.pas
+++ b/src/KM_MapEditor.pas
@@ -32,6 +32,7 @@ type
                              end;
 
     function GetRevealer(aIndex: Byte): TKMPointTagList;
+    procedure ProcessUnitsCursorMode;
   public
     ActiveMarker: TKMMapEdMarker;
 
@@ -61,8 +62,8 @@ type
 
 implementation
 uses
-  KM_HandsCollection, KM_RenderAux, KM_AIDefensePos, KM_UnitGroups, KM_GameCursor, KM_ResHouses,
-  KM_Hand, KM_Houses, KM_HouseBarracks, KM_Game, KM_InterfaceMapEditor;
+  KM_HandsCollection, KM_RenderAux, KM_AIDefensePos, KM_Units, KM_UnitGroups, KM_GameCursor,
+  KM_ResHouses, KM_Hand, KM_Houses, KM_HouseBarracks, KM_Game, KM_InterfaceMapEditor;
 
 
 { TKMMapEditor }
@@ -240,7 +241,7 @@ begin
                       gMySpectator.Hand.AddField(P, ft_Corn);
       cmWine:       if gMySpectator.Hand.CanAddFieldPlan(P, ft_Wine) then
                       gMySpectator.Hand.AddField(P, ft_Wine);
-      cmUnits:      if gGameCursor.Tag1 = 255 then gHands.RemAnyUnit(P);
+      cmUnits:      ProcessUnitsCursorMode;//if gGameCursor.Tag1 = 255 then gHands.RemAnyUnit(P);
       cmErase:      begin
                       gHands.RemAnyHouse(P);
                       if gTerrain.Land[P.Y,P.X].TileOverlay = to_Road then
@@ -250,6 +251,34 @@ begin
                     end;
       cmSelection:  fSelection.Selection_Resize;
     end;
+  end;
+end;
+
+
+procedure TKMMapEditor.ProcessUnitsCursorMode;
+var P: TKMPoint;
+    Obj: TObject;
+begin
+  P := gGameCursor.Cell;
+
+  if gGameCursor.Tag1 = 255 then
+  begin
+    Obj := gMySpectator.HitTestCursor;
+    if Obj is TKMUnit then
+      gHands.RemAnyUnit(TKMUnit(Obj).GetPosition)
+    else
+      gHands.RemAnyUnit(P);
+  end else
+  if gTerrain.CanPlaceUnit(P, TUnitType(gGameCursor.Tag1)) then
+  begin
+    //Check if we can really add a unit
+    if TUnitType(gGameCursor.Tag1) in [CITIZEN_MIN..CITIZEN_MAX] then
+      gMySpectator.Hand.AddUnit(TUnitType(gGameCursor.Tag1), P, False)
+    else
+    if TUnitType(gGameCursor.Tag1) in [WARRIOR_MIN..WARRIOR_MAX] then
+      gMySpectator.Hand.AddUnitGroup(TUnitType(gGameCursor.Tag1), P, dir_S, 1, 1)
+    else
+      gHands.PlayerAnimals.AddUnit(TUnitType(gGameCursor.Tag1), P);
   end;
 end;
 
@@ -300,20 +329,7 @@ begin
                                   gGameCursor.Mode := cmTiles;
                               end;
                 cmRotateTile: fTerrainPainter.RotateTile(P);
-                cmUnits:      if gGameCursor.Tag1 = 255 then
-                                gHands.RemAnyUnit(P)
-                              else
-                              if gTerrain.CanPlaceUnit(P, TUnitType(gGameCursor.Tag1)) then
-                              begin
-                                //Check if we can really add a unit
-                                if TUnitType(gGameCursor.Tag1) in [CITIZEN_MIN..CITIZEN_MAX] then
-                                  gMySpectator.Hand.AddUnit(TUnitType(gGameCursor.Tag1), P, False)
-                                else
-                                if TUnitType(gGameCursor.Tag1) in [WARRIOR_MIN..WARRIOR_MAX] then
-                                  gMySpectator.Hand.AddUnitGroup(TUnitType(gGameCursor.Tag1), P, dir_S, 1, 1)
-                                else
-                                  gHands.PlayerAnimals.AddUnit(TUnitType(gGameCursor.Tag1), P);
-                              end;
+                cmUnits:      ProcessUnitsCursorMode;
                 cmMarkers:    case gGameCursor.Tag1 of
                                 MARKER_REVEAL:        fRevealers[gMySpectator.HandIndex].Add(P, gGameCursor.MapEdSize);
                                 MARKER_DEFENCE:       gMySpectator.Hand.AI.General.DefencePositions.Add(KMPointDir(P, dir_N), gt_Melee, 10, adt_FrontLine);

--- a/src/KM_MapEditor.pas
+++ b/src/KM_MapEditor.pas
@@ -265,9 +265,7 @@ begin
   begin
     Obj := gMySpectator.HitTestCursor;
     if Obj is TKMUnit then
-      gHands.RemAnyUnit(TKMUnit(Obj).GetPosition)
-    else
-      gHands.RemAnyUnit(P);
+      gHands.RemAnyUnit(TKMUnit(Obj).GetPosition);
   end else
   if gTerrain.CanPlaceUnit(P, TUnitType(gGameCursor.Tag1)) then
   begin

--- a/src/KM_MapEditor.pas
+++ b/src/KM_MapEditor.pas
@@ -241,7 +241,7 @@ begin
                       gMySpectator.Hand.AddField(P, ft_Corn);
       cmWine:       if gMySpectator.Hand.CanAddFieldPlan(P, ft_Wine) then
                       gMySpectator.Hand.AddField(P, ft_Wine);
-      cmUnits:      ProcessUnitsCursorMode;//if gGameCursor.Tag1 = 255 then gHands.RemAnyUnit(P);
+      cmUnits:      ProcessUnitsCursorMode;
       cmErase:      begin
                       gHands.RemAnyHouse(P);
                       if gTerrain.Land[P.Y,P.X].TileOverlay = to_Road then


### PR DESCRIPTION
1. while holding left mouse button with while in cm_Units mode will put Unit onto the map
2. Before delete unit used position of cursor over map cell, and when pointing to unit head unit was not highlighted with red. Especially for tall units (knight/scout). That is why it was a little bit unpredictable behaviour - to delete unit, you have to point to his legs.
3. added red highlight for unit groups when deleting