### PR TITLE
BugFix: close drop column/list when control become invisible

### DIFF
--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -172,7 +172,7 @@ type
     procedure Enable;
     procedure Disable;
     procedure Show;
-    procedure Hide; virtual;
+    procedure Hide;
     procedure AnchorsCenter;
     procedure AnchorsStretch;
     function MasterParent: TKMPanel;

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -5526,7 +5526,7 @@ end;
 procedure TKMDropCommon.UpdateVisibility;
 begin
   if not Visible then
-    ListHide(nil);
+    CloseList;
 end;
 
 


### PR DESCRIPTION
fixes this, when server was disconnected or somehow we switched page back while had opened drop list

![bug](https://puu.sh/ucBTA/6197c10657.png)