### PR TITLE
Show controls IDs option in F11 menu

### DIFF
--- a/src/KM_Defaults.pas
+++ b/src/KM_Defaults.pas
@@ -76,7 +76,8 @@ var
   //These are debug things, should be False
   {User interface options}
   SHOW_DEBUG_CONTROLS   :Boolean = False; //Show debug panel / Form1 menu (F11)
-  SHOW_CONTROLS_OVERLAY :Boolean = False; //Draw colored overlays ontop of controls, usefull for making layout (F6)! always Off here
+  SHOW_CONTROLS_OVERLAY :Boolean = False; //Draw colored overlays ontop of controls! always Off here
+  SHOW_CONTROLS_ID      :Boolean = False; //Draw controls ID
   SHOW_CONTROLS_FOCUS   :Boolean = False; //Outline focused control
   SHOW_TEXT_OUTLINES    :Boolean = False; //Display text areas outlines
   ENABLE_DESIGN_CONTORLS:Boolean = False; //Enable special mode to allow to move/edit controls

--- a/src/KM_FormMain.dfm
+++ b/src/KM_FormMain.dfm
@@ -56,10 +56,13 @@ object FormMain: TFormMain
         Width = 80
       end
       item
-        Text = 'Object'
-        Width = 90
+        Text = 'Object '
+        Width = 100
+      end
+      item
+        Text = 'Control ID: '
+        Width = 80
       end>
-    ExplicitTop = 680
   end
   object GroupBox1: TGroupBox
     Left = 320
@@ -185,6 +188,15 @@ object FormMain: TFormMain
         Height = 17
         Caption = 'Text bounds'
         TabOrder = 1
+        OnClick = ControlsUpdate
+      end
+      object chkUIControlsID: TCheckBox
+        Left = 111
+        Top = 16
+        Width = 58
+        Height = 17
+        Caption = 'Ctrls ID'
+        TabOrder = 2
         OnClick = ControlsUpdate
       end
     end

--- a/src/KM_FormMain.pas
+++ b/src/KM_FormMain.pas
@@ -83,6 +83,7 @@ type
     chkLogNetConnection: TCheckBox;
     RGLogNetPackets: TRadioGroup;
     chkLogsShowInChat: TCheckBox;
+    chkUIControlsID: TCheckBox;
     procedure Export_TreeAnim1Click(Sender: TObject);
     procedure MenuItem1Click(Sender: TObject);
     procedure FormKeyUp(Sender: TObject; var Key: Word; Shift: TShiftState);
@@ -531,6 +532,7 @@ begin
   //UI
   SHOW_CONTROLS_OVERLAY := chkUIControlsBounds.Checked;
   SHOW_TEXT_OUTLINES := chkUITextBounds.Checked;
+  SHOW_CONTROLS_ID := chkUIControlsID.Checked;
 
   //Graphics
   if AllowDebugChange then

--- a/src/KM_GameApp.pas
+++ b/src/KM_GameApp.pas
@@ -94,7 +94,7 @@ implementation
 uses
   KM_Log, KM_Main, KM_GameCursor,
   {$IFDEF USE_MAD_EXCEPT} KM_Exceptions, {$ENDIF}
-  KM_Maps, KM_Resource, KM_Sound, KM_Utils, KM_GameInputProcess;
+  KM_Maps, KM_Resource, KM_Sound, KM_Utils, KM_GameInputProcess, KM_Controls;
 
 
 { Creating everything needed for MainMenu, game stuff is created on StartGame }
@@ -287,6 +287,8 @@ end;
 
 
 procedure TKMGameApp.MouseMove(Shift: TShiftState; X,Y: Integer);
+var Ctrl: TKMControl;
+    CtrlID: Integer;
 begin
   if not InRange(X, 1, fRender.ScreenX - 1)
   or not InRange(Y, 1, fRender.ScreenY - 1) then
@@ -305,6 +307,17 @@ begin
     fOnCursorUpdate(2, Format('Tile: %.1f:%.1f [%d:%d]',
                               [gGameCursor.Float.X, gGameCursor.Float.Y,
                               gGameCursor.Cell.X, gGameCursor.Cell.Y]));
+    if SHOW_CONTROLS_ID then
+    begin
+      if gGame <> nil then
+        Ctrl := gGame.ActiveInterface.MyControls.HitControl(X,Y, True)
+      else
+        Ctrl := fMainMenuInterface.MyControls.HitControl(X,Y, True);
+      CtrlID := -1;
+      if Ctrl <> nil then
+        CtrlID := Ctrl.ID;
+      fOnCursorUpdate(6, Format('Control ID: %d', [CtrlID]));
+    end;
   end;
 end;
 


### PR DESCRIPTION
Draw Ctrl ID as text (similar to draw control bounds) and show Ctrl ID in status on mouse over.
Usefull for controls debugging