### PR TITLE
Added ability to add map pdf's readme with with different translations (locales)

### DIFF
--- a/src/KM_Maps.pas
+++ b/src/KM_Maps.pas
@@ -43,6 +43,7 @@ type
     procedure LoadFromFile(const aPath: string);
     procedure SaveToFile(const aPath: string);
     function GetSizeText: string;
+    function DetermineReadmeFilePath: AnsiString;
   public
     MapSizeX, MapSizeY: Integer;
     MissionMode: TKMissionMode;
@@ -567,15 +568,38 @@ begin
 end;
 
 
+function TKMapInfo.DetermineReadmeFilePath: AnsiString;
+var Path, Locale: AnsiString;
+begin
+  Result := '';
+  Locale := gGameApp.GameSettings.Locale;
+  Path := fPath + fFileName + '.' + Locale + '.pdf'; // Try to file with our locale first
+  if FileExists(Path) then
+    Result := Path
+  else
+  begin
+    Path := fPath + fFileName + '.' + DEFAULT_LOCALE + '.pdf'; // then with default locale
+    if FileExists(Path) then
+      Result := Path
+    else
+    begin
+      Path := fPath + fFileName + '.pdf'; // and finally without any locale
+      if FileExists(Path) then
+        Result := Path;
+    end;
+  end;
+end;
+
+
 function TKMapInfo.HasReadme: Boolean;
 begin
-  Result := FileExists(fPath + fFileName + '.pdf');
+  Result := DetermineReadmeFilePath <> '';
 end;
 
 
 function TKMapInfo.ViewReadme: Boolean;
 begin
-  Result := OpenPDF(fPath + fFileName + '.pdf');
+  Result := OpenPDF(DetermineReadmeFilePath);
 end;
 
 


### PR DESCRIPTION
1. try to find pdf readme file with our locale suffix (mymap.rus.pdf)
2. if not found - with default locale suffix (mymap.eng.pdf)
3. if not found - without locale suffix (mymap.pdf) - for back compatibility 