### PR TITLE
BugFix: scripting action OnHousePlanRemove was invoked with wrong coord

### DIFF
--- a/src/KM_BuildList.pas
+++ b/src/KM_BuildList.pas
@@ -40,22 +40,26 @@ type
   end;
 
 
+  TKMHousePlan = record
+    HouseType: THouseType;
+    Loc: TKMPoint;
+    JobStatus: TJobStatus;
+    Worker: TKMUnit; //So we can tell Worker if plan is cancelled
+  end;
+
+
   //List of house plans and workers assigned to them
   TKMHousePlanList = class
   private
     fPlansCount: Integer;
-    fPlans: array of record
-      HouseType: THouseType;
-      Loc: TKMPoint;
-      JobStatus: TJobStatus;
-      Worker: TKMUnit; //So we can tell Worker if plan is cancelled
-    end;
+    fPlans: array of TKMHousePlan;
+    function GetEmptyPlan: TKMHousePlan;
   public
     //Player orders
     procedure AddPlan(aHouseType: THouseType; aLoc: TKMPoint);
     function HasPlan(aLoc: TKMPoint): Boolean;
     procedure RemPlan(aLoc: TKMPoint);
-    function GetPlan(aLoc: TKMPoint): THouseType;
+    function GetPlan(aLoc: TKMPoint): TKMHousePlan;
     function FindHousePlan(aLoc: TKMPoint; aSkip: TKMPoint; out aOut: TKMPoint): Boolean;
 
     //Game events
@@ -782,11 +786,20 @@ begin
 end;
 
 
-function TKMHousePlanList.GetPlan(aLoc: TKMPoint): THouseType;
+function TKMHousePlanList.GetEmptyPlan: TKMHousePlan;
+begin
+  Result.HouseType := ht_None;
+  Result.Loc := ZERO_POINT;
+  Result.JobStatus := js_Empty;
+  Result.Worker := nil;
+end;
+
+
+function TKMHousePlanList.GetPlan(aLoc: TKMPoint): TKMHousePlan;
 var
   I: Integer;
 begin
-  Result := ht_None;
+  Result := GetEmptyPlan;
   for I := 0 to fPlansCount - 1 do
   if (fPlans[I].HouseType <> ht_None)
   and ((aLoc.X - fPlans[I].Loc.X + 3 in [1..4]) and
@@ -794,7 +807,7 @@ begin
        (gRes.Houses[fPlans[I].HouseType].BuildArea[aLoc.Y - fPlans[I].Loc.Y + 4, aLoc.X - fPlans[I].Loc.X + 3] <> 0))
   then
   begin
-    Result := fPlans[I].HouseType;
+    Result := fPlans[I];
     Exit;
   end;
 end;

--- a/src/KM_BuildList.pas
+++ b/src/KM_BuildList.pas
@@ -53,13 +53,12 @@ type
   private
     fPlansCount: Integer;
     fPlans: array of TKMHousePlan;
-    function GetEmptyPlan: TKMHousePlan;
   public
     //Player orders
     procedure AddPlan(aHouseType: THouseType; aLoc: TKMPoint);
     function HasPlan(aLoc: TKMPoint): Boolean;
     procedure RemPlan(aLoc: TKMPoint);
-    function GetPlan(aLoc: TKMPoint): TKMHousePlan;
+    function TryGetPlan(aLoc: TKMPoint; out oHousePlan: TKMHousePlan): Boolean;
     function FindHousePlan(aLoc: TKMPoint; aSkip: TKMPoint; out aOut: TKMPoint): Boolean;
 
     //Game events
@@ -786,20 +785,11 @@ begin
 end;
 
 
-function TKMHousePlanList.GetEmptyPlan: TKMHousePlan;
-begin
-  Result.HouseType := ht_None;
-  Result.Loc := ZERO_POINT;
-  Result.JobStatus := js_Empty;
-  Result.Worker := nil;
-end;
-
-
-function TKMHousePlanList.GetPlan(aLoc: TKMPoint): TKMHousePlan;
+function TKMHousePlanList.TryGetPlan(aLoc: TKMPoint; out oHousePlan: TKMHousePlan): Boolean;
 var
   I: Integer;
 begin
-  Result := GetEmptyPlan;
+  Result := False;
   for I := 0 to fPlansCount - 1 do
   if (fPlans[I].HouseType <> ht_None)
   and ((aLoc.X - fPlans[I].Loc.X + 3 in [1..4]) and
@@ -807,7 +797,8 @@ begin
        (gRes.Houses[fPlans[I].HouseType].BuildArea[aLoc.Y - fPlans[I].Loc.Y + 4, aLoc.X - fPlans[I].Loc.X + 3] <> 0))
   then
   begin
-    Result := fPlans[I];
+    oHousePlan := fPlans[I];
+    Result := True;
     Exit;
   end;
 end;

--- a/src/KM_Points.pas
+++ b/src/KM_Points.pas
@@ -111,6 +111,7 @@ type
 
 
 const
+  ZERO_POINT: TKMPoint = (X: 0; Y: 0);
   INVALID_MAP_POINT: TKMPoint = (X: -1; Y: -1);
 
 

--- a/src/hands/KM_Hand.pas
+++ b/src/hands/KM_Hand.pas
@@ -798,14 +798,14 @@ end;
 
 procedure TKMHand.RemHousePlan(Position: TKMPoint);
 var
-  HT: THouseType;
+  HPlan: TKMHousePlan;
 begin
-  HT := fBuildList.HousePlanList.GetPlan(Position);
-  if HT = ht_None then Exit; //Due to network delays house might not exist now
+  HPlan := fBuildList.HousePlanList.GetPlan(Position);
+  if HPlan.HouseType = ht_None then Exit; //Due to network delays house might not exist now
 
   fBuildList.HousePlanList.RemPlan(Position);
-  fStats.HousePlanRemoved(HT);
-  gScriptEvents.ProcHousePlanRemoved(fHandIndex, Position.X, Position.Y, HT);
+  fStats.HousePlanRemoved(HPlan.HouseType);
+  gScriptEvents.ProcHousePlanRemoved(fHandIndex, HPlan.Loc.X, HPlan.Loc.Y, HPlan.HouseType);
   if (HandIndex = gMySpectator.HandIndex) and not (gGame.GameMode in [gmMultiSpectate, gmReplaySingle, gmReplayMulti]) then
     gSoundPlayer.Play(sfx_Click);
 end;

--- a/src/hands/KM_Hand.pas
+++ b/src/hands/KM_Hand.pas
@@ -800,8 +800,8 @@ procedure TKMHand.RemHousePlan(Position: TKMPoint);
 var
   HPlan: TKMHousePlan;
 begin
-  HPlan := fBuildList.HousePlanList.GetPlan(Position);
-  if HPlan.HouseType = ht_None then Exit; //Due to network delays house might not exist now
+  if not fBuildList.HousePlanList.TryGetPlan(Position, HPlan) then //Due to network delays house might not exist now
+    Exit;
 
   fBuildList.HousePlanList.RemPlan(Position);
   fStats.HousePlanRemoved(HPlan.HouseType);

--- a/src/scripting/KM_ScriptingActions.pas
+++ b/src/scripting/KM_ScriptingActions.pas
@@ -2299,8 +2299,7 @@ begin
     if InRange(aPlayer, 0, gHands.Count - 1) and (gHands[aPlayer].Enabled)
     and gTerrain.TileInMapCoords(X,Y) then
     begin
-      HPlan := gHands[aPlayer].BuildList.HousePlanList.GetPlan(KMPoint(X, Y));
-      if HPlan.HouseType <> ht_None then
+      if gHands[aPlayer].BuildList.HousePlanList.TryGetPlan(KMPoint(X, Y), HPlan) then
       begin
         gHands[aPlayer].BuildList.HousePlanList.RemPlan(KMPoint(X, Y));
         gHands[aPlayer].Stats.HousePlanRemoved(HPlan.HouseType);

--- a/src/scripting/KM_ScriptingActions.pas
+++ b/src/scripting/KM_ScriptingActions.pas
@@ -144,7 +144,7 @@ uses
   KM_AI, KM_Terrain, KM_Game, KM_FogOfWar, KM_HandsCollection, KM_Units_Warrior, KM_HandLogistics,
   KM_HouseBarracks, KM_HouseSchool, KM_ResUnits, KM_Log, KM_Utils, KM_HouseMarket,
   KM_Resource, KM_UnitTaskSelfTrain, KM_Sound, KM_Hand, KM_AIDefensePos, KM_CommonClasses,
-  KM_UnitsCollection, KM_PathFindingRoad, KM_ResMapElements;
+  KM_UnitsCollection, KM_PathFindingRoad, KM_ResMapElements, KM_BuildList;
 
 
   //We need to check all input parameters as could be wildly off range due to
@@ -2291,7 +2291,7 @@ end;
 //* Returns true if the plan was successfully removed or false if it failed (e.g. tile blocked)
 function TKMScriptActions.PlanRemove(aPlayer, X, Y: Word): Boolean;
 var
-  HT: THouseType;
+  HPlan: TKMHousePlan;
 begin
   try
     Result := False;
@@ -2299,11 +2299,11 @@ begin
     if InRange(aPlayer, 0, gHands.Count - 1) and (gHands[aPlayer].Enabled)
     and gTerrain.TileInMapCoords(X,Y) then
     begin
-      HT := gHands[aPlayer].BuildList.HousePlanList.GetPlan(KMPoint(X, Y));
-      if HT <> ht_None then
+      HPlan := gHands[aPlayer].BuildList.HousePlanList.GetPlan(KMPoint(X, Y));
+      if HPlan.HouseType <> ht_None then
       begin
         gHands[aPlayer].BuildList.HousePlanList.RemPlan(KMPoint(X, Y));
-        gHands[aPlayer].Stats.HousePlanRemoved(HT);
+        gHands[aPlayer].Stats.HousePlanRemoved(HPlan.HouseType);
         Result := True;
       end;
       if gHands[aPlayer].BuildList.FieldworksList.HasField(KMPoint(X, Y)) <> ft_None then


### PR DESCRIPTION
Bug occurs, because when we invoke OnHousePlanRemove we use location, where user clicks (then GIP command is produced with click coordinates). Instead we must use HousePlan coordinates