### PR TITLE
Replay view/Spectating: unfocus from players list on Esc key

### DIFF
--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -16,7 +16,7 @@ type
   TNotifyEventKey = procedure(Sender: TObject; Key: Word) of object;
   TNotifyEventKeyFunc = function(Sender: TObject; Key: Word): Boolean of object;
   TNotifyEventKeyShift = procedure(Key: Word; Shift: TShiftState) of object;
-  TNotifyEventKeyShiftFunc = function(Key: Word; Shift: TShiftState): Boolean of object;
+  TNotifyEventKeyShiftFunc = function(Sender: TObject; Key: Word; Shift: TShiftState): Boolean of object;
   TNotifyEventXY = procedure(Sender: TObject; X, Y: Integer) of object;
 
   TKMControlState = (csDown, csFocus, csOver);
@@ -51,6 +51,7 @@ type
 
     property MainPanel: TKMPanel read fCtrl;
     function IsFocusAllowed(aCtrl: TKMControl): Boolean;
+    function IsAutoFocusAllowed(aCtrl: TKMControl): Boolean;
     procedure UpdateFocus(aSender: TKMControl);
 
     property CtrlDown: TKMControl read fCtrlDown write SetCtrlDown;
@@ -107,6 +108,8 @@ type
     fOnFocus: TNotifyEventFocus;
     fOnControlMouseDown: TNotifyEventShift;
     fOnControlMouseUp: TNotifyEventShift;
+    fOnKeyDown: TNotifyEventKeyShiftFunc;
+    fOnKeyUp: TNotifyEventKeyShiftFunc;
 
     function GetAbsLeft: Integer;
     function GetAbsTop: Integer;
@@ -142,6 +145,7 @@ type
   public
     Hitable: Boolean; //Can this control be hit with the cursor?
     Focusable: Boolean; //Can this control have focus (e.g. TKMEdit sets this true)
+    AutoFocusable: Boolean; //Can we focus on this element automatically (f.e. if set to False we will able to Focus only by manual mouse click)
 
     State: TKMControlStateSet; //Each control has it localy to avoid quering Collection on each Render
     Scale: Single; //Child controls position is scaled
@@ -180,6 +184,7 @@ type
     procedure Disable;
     procedure Show;
     procedure Hide;
+    procedure Unfocus;
     procedure AnchorsCenter;
     procedure AnchorsStretch;
     function MasterParent: TKMPanel;
@@ -200,6 +205,8 @@ type
     property OnFocus: TNotifyEventFocus read fOnFocus write fOnFocus;
     property OnControlMouseDown: TNotifyEventShift read fOnControlMouseDown write fOnControlMouseDown;
     property OnControlMouseUp: TNotifyEventShift read fOnControlMouseUp write fOnControlMouseUp;
+    property OnKeyDown: TNotifyEventKeyShiftFunc read fOnKeyDown write fOnKeyDown;
+    property OnKeyUp: TNotifyEventKeyShiftFunc read fOnKeyUp write fOnKeyUp;
 
     procedure Paint; virtual;
   end;
@@ -491,7 +498,6 @@ type
     DrawOutline: Boolean;
     OutlineColor: Cardinal;
     OnChange: TNotifyEvent;
-    OnKeyDown: TNotifyEventKey;
     OnIsKeyEventHandled: TNotifyEventKeyFunc; //Invoked to check is key overrides default handle policy or not
     constructor Create(aParent: TKMPanel; aLeft, aTop, aWidth, aHeight: Integer; aFont: TKMFont; aSelectable: Boolean = True);
 
@@ -751,7 +757,6 @@ type
     function GetSelfWidth: Integer; override;
   public
     ItemTags: array of Integer;
-    OnKeyDown: TNotifyEventKeyShiftFunc;
     constructor Create(aParent: TKMPanel; aLeft, aTop, aWidth, aHeight: Integer; aFont: TKMFont; aStyle: TKMButtonStyle);
     destructor Destroy; override;
 
@@ -895,8 +900,8 @@ type
     HighlightError: Boolean;
     HighlightOnMouseOver: Boolean;
     Rows: array of TKMListRow; //Exposed to public since we need to edit sub-fields
-    OnKeyDown: TNotifyEventKeyShiftFunc;
-    OnKeyUp: TNotifyEventKeyShiftFunc;
+//    OnKeyDown: TNotifyEventKeyShiftFunc;
+//    OnKeyUp: TNotifyEventKeyShiftFunc;
     PassAllKeys: Boolean;
 
     constructor Create(aParent: TKMPanel; aLeft, aTop, aWidth, aHeight: Integer; aFont: TKMFont; aStyle: TKMButtonStyle);
@@ -964,7 +969,7 @@ type
     procedure SetTop(aValue: Integer); override;
     procedure SetEnabled(aValue: Boolean); override;
     procedure SetVisible(aValue: Boolean); override;
-    function ListKeyDown(Key: Word; Shift: TShiftState): Boolean;
+    function ListKeyDown(Sender: TObject; Key: Word; Shift: TShiftState): Boolean;
     procedure UpdateVisibility; override;
   public
     constructor Create(aParent: TKMPanel; aLeft, aTop, aWidth, aHeight: Integer; aFont: TKMFont; aStyle: TKMButtonStyle; aAutoClose: Boolean = True);
@@ -1375,24 +1380,25 @@ end;
 constructor TKMControl.Create(aParent: TKMPanel; aLeft, aTop, aWidth, aHeight: Integer);
 begin
   inherited Create;
-  Scale       := 1;
-  Hitable     := True; //All controls can be clicked by default
-  fLeft       := aLeft;
-  fTop        := aTop;
-  fWidth      := aWidth;
-  fHeight     := aHeight;
-  Anchors     := [anLeft, anTop];
-  State       := [];
-  fEnabled    := True;
-  fVisible    := True;
-  Tag         := 0;
-  Hint        := '';
+  Scale         := 1;
+  Hitable       := True; //All controls can be clicked by default
+  fLeft         := aLeft;
+  fTop          := aTop;
+  fWidth        := aWidth;
+  fHeight       := aHeight;
+  Anchors       := [anLeft, anTop];
+  State         := [];
+  fEnabled      := True;
+  fVisible      := True;
+  Tag           := 0;
+  Hint          := '';
   fControlIndex := -1;
+  AutoFocusable := True;
+
   if aParent <> nil then
     fID := aParent.fMasterControl.GetNextCtrlID
   else if Self is TKMPanel then
     fID := 0;
-    
 
   //Parent will be Nil only for master Panel which contains all the controls in it
   fParent   := aParent;
@@ -1405,6 +1411,9 @@ function TKMControl.KeyDown(Key: Word; Shift: TShiftState): Boolean;
 var Amt: Byte;
 begin
   Result := MODE_DESIGN_CONTORLS;
+
+  if Assigned(fOnKeyDown) then
+    Result := fOnKeyDown(Self, Key, Shift);
 
   if MODE_DESIGN_CONTORLS then
   begin
@@ -1428,15 +1437,18 @@ end;
 
 function TKMControl.KeyUp(Key: Word; Shift: TShiftState): Boolean;
 begin
-  Result := false;
+  Result := False;
   if (Key = VK_TAB) and IsFocused then
   begin
     Parent.FocusNext;
     Result := True;
     Exit;
   end;
-  if not MODE_DESIGN_CONTORLS then exit;
-  //nothing yet
+
+  if Assigned(fOnKeyUp) then
+    Result := fOnKeyUp(Self, Key, Shift);
+
+  if not MODE_DESIGN_CONTORLS then Exit;
 end;
 
 
@@ -1772,6 +1784,12 @@ procedure TKMControl.AnchorsCenter;  begin Anchors := []; end;
 procedure TKMControl.AnchorsStretch; begin Anchors := [anLeft, anTop, anRight, anBottom]; end;
 
 
+procedure TKMControl.Unfocus;
+begin
+  Parent.fMasterControl.CtrlFocus := nil;
+end;
+
+
 function TKMControl.MasterParent: TKMPanel;
 var P: TKMPanel;
 begin
@@ -1834,7 +1852,7 @@ begin
   Result := nil;
   CtrlToFocusI := -1;
   for I := 0 to ChildCount - 1 do
-    if fMasterControl.IsFocusAllowed(Childs[I]) and (
+    if fMasterControl.IsAutoFocusAllowed(Childs[I]) and (
       (FocusedControlIndex = -1)                          // If FocusControl was not set (no focused element on panel)
       or (FocusedControlIndex = Childs[I].ControlIndex) // We've found last focused Control
       or (CtrlToFocusI <> -1)) then                         // We did find last focused Control on previos iterations
@@ -1857,7 +1875,7 @@ begin
   begin
     // We will try to find it until the same Control, that we find before in previous For cycle
     for I := 0 to CtrlToFocusI do // So if there will be no proper controls, then set focus again to same control with I = CtrlToFocusI
-      if fMasterControl.IsFocusAllowed(Childs[I]) then
+      if fMasterControl.IsAutoFocusAllowed(Childs[I]) then
       begin
         Result := Childs[I];
         Exit;
@@ -2848,7 +2866,7 @@ begin
 
 
   if Assigned(OnKeyDown) then
-    OnKeyDown(Self, Key);
+    OnKeyDown(Self, Key, Shift);
 end;
 
 
@@ -4610,7 +4628,7 @@ begin
                 end;
     else        begin
                   if Assigned(OnKeyDown) then
-                    Result := OnKeyDown(Key, Shift);
+                    Result := OnKeyDown(Self, Key, Shift);
                   Exit;
                 end;
   end;
@@ -5134,14 +5152,17 @@ end;
 
 function TKMColumnBox.KeyUp(Key: Word; Shift: TShiftState): Boolean;
 begin
-  Result := False;
+  Result := inherited KeyUp(Key, Shift);
+
+  if Result then Exit;
+
   if PassAllKeys then
   begin
     // Assume handler always handles the KeyUp
     Result := Assigned(OnKeyUp);
 
     if Assigned(OnKeyUp) then
-      OnKeyUp(Key, Shift);
+      OnKeyUp(Self, Key, Shift);
   end
 end;
 
@@ -5180,11 +5201,7 @@ begin
                       fOnDoubleClick(Self);
                   Exit;
                 end;
-    else        begin
-                  if Assigned(OnKeyDown) then
-                    Result := OnKeyDown(Key, Shift);
-                  Exit;
-                end;
+    else        Exit;
   end;
 
   if InRange(NewIndex, 0, fRowCount - 1) then
@@ -5658,7 +5675,7 @@ end;
 
 
 //Handle KeyDown on List
-function TKMDropCommon.ListKeyDown(Key: Word; Shift: TShiftState): Boolean;
+function TKMDropCommon.ListKeyDown(Sender: TObject; Key: Word; Shift: TShiftState): Boolean;
 begin
   if fAutoClose and (Key = VK_ESCAPE) then // Close List on ESC, if autoclosable
   begin
@@ -6798,13 +6815,20 @@ begin
 end;
 
 
-//Check If Control if it is allowed to be focused on
+//Check If Control if it is allowed to be focused on (manual or automatically)
 function TKMMasterControl.IsFocusAllowed(aCtrl: TKMControl): Boolean;
 begin
   Result := aCtrl.fVisible
         and aCtrl.Enabled
         and aCtrl.Focusable
         and not IsCtrlCovered(aCtrl); // Do not allow to focus on covered Controls
+end;
+
+
+//Check If Control if it is allowed to be automatically (not manual, by user) focused on
+function TKMMasterControl.IsAutoFocusAllowed(aCtrl: TKMControl): Boolean;
+begin
+  Result := aCtrl.AutoFocusable and IsFocusAllowed(aCtrl);
 end;
 
 

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -900,8 +900,6 @@ type
     HighlightError: Boolean;
     HighlightOnMouseOver: Boolean;
     Rows: array of TKMListRow; //Exposed to public since we need to edit sub-fields
-//    OnKeyDown: TNotifyEventKeyShiftFunc;
-//    OnKeyUp: TNotifyEventKeyShiftFunc;
     PassAllKeys: Boolean;
 
     constructor Create(aParent: TKMPanel; aLeft, aTop, aWidth, aHeight: Integer; aFont: TKMFont; aStyle: TKMButtonStyle);
@@ -2863,10 +2861,6 @@ begin
       VK_HOME:    begin CursorPos := 0; ResetSelection; end;
       VK_END:     begin CursorPos := Length(fText); ResetSelection; end;
     end;
-
-
-  if Assigned(OnKeyDown) then
-    OnKeyDown(Self, Key, Shift);
 end;
 
 
@@ -4626,11 +4620,7 @@ begin
                     fOnClick(Self);
                   Exit;
                 end;
-    else        begin
-                  if Assigned(OnKeyDown) then
-                    Result := OnKeyDown(Self, Key, Shift);
-                  Exit;
-                end;
+    else        Exit;
   end;
 
   if InRange(NewIndex, 0, Count - 1) then

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -929,7 +929,6 @@ type
     property SortIndex: Integer read GetSortIndex write SetSortIndex;
     property SortDirection: TSortDirection read GetSortDirection write SetSortDirection;
 
-    function KeyUp(Key: Word; Shift: TShiftState): Boolean; override;
     function KeyDown(Key: Word; Shift: TShiftState): Boolean; override;
     procedure KeyPress(Key: Char); override;
     procedure MouseDown(X,Y: Integer; Shift: TShiftState; Button: TMouseButton); override;
@@ -5137,23 +5136,6 @@ var
 begin
   for I := 0 to fHeader.ColumnCount - 1 do
     FreeAndNil(fColumns[I]);
-end;
-
-
-function TKMColumnBox.KeyUp(Key: Word; Shift: TShiftState): Boolean;
-begin
-  Result := inherited KeyUp(Key, Shift);
-
-  if Result then Exit;
-
-  if PassAllKeys then
-  begin
-    // Assume handler always handles the KeyUp
-    Result := Assigned(OnKeyUp);
-
-    if Assigned(OnKeyUp) then
-      OnKeyUp(Self, Key, Shift);
-  end
 end;
 
 

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -126,6 +126,7 @@ type
     procedure MPPlayMoreClick(Sender: TObject);
     procedure NetWaitClick(Sender: TObject);
     procedure ReplayClick(Sender: TObject);
+    function Replay_KeyDown(Sender: TObject; Key: Word; Shift: TShiftState): Boolean;
     procedure ReturnToLobbyClick(Sender: TObject);
     procedure Allies_Close(Sender: TObject);
     procedure Allies_Mute(Sender: TObject);
@@ -1005,6 +1006,8 @@ begin
     Dropbox_ReplayFOW := TKMDropList.Create(Panel_ReplayFOW, 0, 19, 160, 20, fnt_Metal, '', bsGame, False, 0.5);
     Dropbox_ReplayFOW.Hint := gResTexts[TX_REPLAY_PLAYER_PERSPECTIVE];
     Dropbox_ReplayFOW.OnChange := ReplayClick;
+    Dropbox_ReplayFOW.List.AutoFocusable := False;
+    Dropbox_ReplayFOW.List.OnKeyUp := Replay_KeyDown;
     Dropbox_ReplayFOW.List.OnDoubleClick := Replay_ListDoubleClick;
  end;
 
@@ -1833,6 +1836,19 @@ begin
       fViewport.Position := KMPointF(gHands[gMySpectator.HandIndex].CenterScreen); //By default set viewport position to hand CenterScreen
 
   gMySpectator.Selected := LastSelectedObj;  // Change selected object to last one for this hand or Reset it to nil
+end;
+
+
+function TKMGamePlayInterface.Replay_KeyDown(Sender: TObject; Key: Word; Shift: TShiftState): Boolean;
+begin
+  Result := False;
+  case Key of
+    VK_ESCAPE:  if Sender = Dropbox_ReplayFOW.List then
+                begin
+                  TKMListBox(Sender).Unfocus;
+                  Result := True;
+                end;
+  end;
 end;
 
 

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -126,7 +126,7 @@ type
     procedure MPPlayMoreClick(Sender: TObject);
     procedure NetWaitClick(Sender: TObject);
     procedure ReplayClick(Sender: TObject);
-    function Replay_KeyDown(Sender: TObject; Key: Word; Shift: TShiftState): Boolean;
+    function Replay_ListKeyUp(Sender: TObject; Key: Word; Shift: TShiftState): Boolean;
     procedure ReturnToLobbyClick(Sender: TObject);
     procedure Allies_Close(Sender: TObject);
     procedure Allies_Mute(Sender: TObject);
@@ -1009,7 +1009,7 @@ begin
     Dropbox_ReplayFOW.Hint := gResTexts[TX_REPLAY_PLAYER_PERSPECTIVE];
     Dropbox_ReplayFOW.OnChange := ReplayClick;
     Dropbox_ReplayFOW.List.AutoFocusable := False;
-    Dropbox_ReplayFOW.List.OnKeyUp := Replay_KeyDown;
+    Dropbox_ReplayFOW.List.OnKeyUp := Replay_ListKeyUp;
     Dropbox_ReplayFOW.List.OnDoubleClick := Replay_ListDoubleClick;
  end;
 
@@ -1859,7 +1859,7 @@ begin
 end;
 
 
-function TKMGamePlayInterface.Replay_KeyDown(Sender: TObject; Key: Word; Shift: TShiftState): Boolean;
+function TKMGamePlayInterface.Replay_ListKeyUp(Sender: TObject; Key: Word; Shift: TShiftState): Boolean;
 begin
   Result := False;
   case Key of

--- a/src/gui/pages_game/KM_GUIGameChat.pas
+++ b/src/gui/pages_game/KM_GUIGameChat.pas
@@ -4,7 +4,7 @@ interface
 uses
   {$IFDEF MSWindows} Windows, {$ENDIF}
   {$IFDEF Unix} LCLIntf, LCLType, {$ENDIF}
-  Math, StrUtils, SysUtils,
+  Classes, Math, StrUtils, SysUtils,
   KM_Controls, KM_Defaults, KM_InterfaceDefaults, KM_InterfaceGame, KM_Networking, KM_Points;
 
 
@@ -15,7 +15,7 @@ type
     fChatWhisperRecipient: Integer; //NetPlayer index of the player who will receive the whisper
     fLastChatTime: Cardinal; //Last time a chat message was sent to enforce cooldown
     procedure Chat_Close(Sender: TObject);
-    procedure Chat_Post(Sender: TObject; Key: Word);
+    function Chat_Post(Sender: TObject; Key: Word; Shift: TShiftState): Boolean;
     procedure Chat_Resize(Sender: TObject; X,Y: Integer);
     procedure Chat_MenuClick(Sender: TObject);
     procedure Chat_MenuSelect(aItem: Integer);
@@ -120,8 +120,9 @@ begin
 end;
 
 
-procedure TKMGUIGameChat.Chat_Post(Sender: TObject; Key: Word);
+function TKMGUIGameChat.Chat_Post(Sender: TObject; Key: Word; Shift: TShiftState): Boolean;
 begin
+  Result := False;
   if IsKeyEvent_Return_Handled(Self, Key)
     and (Trim(Edit_ChatMsg.Text) <> '')
     and (GetTimeSince(fLastChatTime) >= CHAT_COOLDOWN) then
@@ -137,9 +138,10 @@ begin
                                           csSystem);
         Chat_MenuSelect(CHAT_MENU_ALL);
       end else
-      gGame.Networking.PostChat(Edit_ChatMsg.Text, fChatMode, gGame.Networking.NetPlayers[fChatWhisperRecipient].IndexOnServer)
+        gGame.Networking.PostChat(Edit_ChatMsg.Text, fChatMode, gGame.Networking.NetPlayers[fChatWhisperRecipient].IndexOnServer)
     end else
       gGame.Networking.PostChat(Edit_ChatMsg.Text, fChatMode);
+    Result := True;
     Edit_ChatMsg.Text := '';
   end;
 end;

--- a/src/gui/pages_menu/KM_GUIMenuLobby.pas
+++ b/src/gui/pages_menu/KM_GUIMenuLobby.pas
@@ -73,7 +73,7 @@ type
     procedure MapChange(Sender: TObject);
     function DropColMapsCellClick(Sender: TObject; const X, Y: Integer): Boolean;
     function DropColPlayersCellClick(Sender: TObject; const X, Y: Integer): Boolean;
-    procedure PostKeyDown(Sender: TObject; Key: Word);
+    function PostKeyDown(Sender: TObject; Key: Word; Shift: TShiftState): Boolean;
     function IsKeyEvent_Return_Handled(Sender: TObject; Key: Word): Boolean;
 
     procedure MinimapLocClick(aValue: Integer);
@@ -2051,11 +2051,12 @@ end;
 
 
 //Post what user has typed
-procedure TKMMenuLobby.PostKeyDown(Sender: TObject; Key: Word);
+function TKMMenuLobby.PostKeyDown(Sender: TObject; Key: Word; Shift: TShiftState): Boolean;
 var
   ChatMessage: UnicodeString;
   RecipientNetIndex: Integer;
 begin
+  Result := False;
   if not IsKeyEvent_Return_Handled(Self, Key)
     or (Trim(Edit_LobbyPost.Text) = '')
     or (GetTimeSince(fLastChatTime) < CHAT_COOLDOWN) then
@@ -2089,6 +2090,7 @@ begin
       fNetworking.PostChat(ChatMessage, fChatMode, fChatWhisperRecipient);
   end else
     fNetworking.PostChat(ChatMessage, fChatMode, fChatWhisperRecipient);
+  Result := True;
   Edit_LobbyPost.Text := '';
 end;
 

--- a/src/gui/pages_menu/KM_GUIMenuOptions.pas
+++ b/src/gui/pages_menu/KM_GUIMenuOptions.pas
@@ -547,7 +547,7 @@ function TKMMenuOptions.KeysUpdate(Sender: TObject; Key: Word; Shift: TShiftStat
 var
   id: Integer;
 begin
-  Result := True; // This Result is not used outside, so we do not care about its value
+  Result := True; // We handle all keys here
   if ColumnBox_OptionsKeys.ItemIndex = -1 then Exit;
 
   ColumnBox_OptionsKeys.HighlightError := False;

--- a/src/gui/pages_menu/KM_GUIMenuOptions.pas
+++ b/src/gui/pages_menu/KM_GUIMenuOptions.pas
@@ -33,7 +33,7 @@ type
     procedure RefreshResolutions;
     procedure KeysClick(Sender: TObject);
     procedure KeysRefreshList;
-    function KeysUpdate(Key: Word; Shift: TShiftState): Boolean;
+    function KeysUpdate(Sender: TObject; Key: Word; Shift: TShiftState): Boolean;
   protected
     Panel_Options: TKMPanel;
       Panel_Options_GFX: TKMPanel;
@@ -503,7 +503,7 @@ begin
     PopUp_OptionsKeys.Hide;
 
   if (Sender = Button_OptionsKeysClear) then
-    KeysUpdate(0, []);
+    KeysUpdate(Button_OptionsKeysClear, 0, []);
 
   if Sender = Button_OptionsKeysReset then
   begin
@@ -543,7 +543,7 @@ begin
 end;
 
 
-function TKMMenuOptions.KeysUpdate(Key: Word; Shift: TShiftState): Boolean;
+function TKMMenuOptions.KeysUpdate(Sender: TObject; Key: Word; Shift: TShiftState): Boolean;
 var
   id: Integer;
 begin


### PR DESCRIPTION
Then this will let use arrow keys for map browsing.

Also moved to TKMControl fOnKeyUp/Down for easier maintanance of keys events globally in TKMControl, rather then in TKMEdit/List/ColumnBox etc.

Also added AutoFocusable flag to TKMControl, to mark if control can or can not be focused via our automatic focus logic in TKMMasterControl.UpdateFocus.
We can't use Focusable flag there, because we still have to be able to focus on control with mouse click by user.

This PR use #305 for testing convenience, so please merge #305 first.