### PR TITLE
MP game: change speedup default speed from 1 to game speed (before after PT). 

### DIFF
--- a/src/KM_CommonTypes.pas
+++ b/src/KM_CommonTypes.pas
@@ -22,6 +22,7 @@ type
   TPointEventFunc = function (Sender: TObject; const X,Y: Integer): Boolean of object;
   TBooleanEvent = procedure (aValue: Boolean) of object;
   TIntegerEvent = procedure (aValue: Integer) of object;
+  TSingleEvent = procedure (aValue: Single) of object;
   TUnicodeStringEvent = procedure (const aData: UnicodeString) of object;
   TUnicodeStringBoolEvent = procedure (const aData: UnicodeString; aBool: Boolean) of object;
   TGameStartEvent = procedure (const aData: UnicodeString; Spectating: Boolean) of object;

--- a/src/KM_FormMain.pas
+++ b/src/KM_FormMain.pas
@@ -436,7 +436,6 @@ end;
 
 
 procedure TFormMain.chkSuperSpeedClick(Sender: TObject);
-var Speed: Single;
 begin
   if (gGameApp.Game = nil)
   or (gGameApp.Game.IsMultiplayer
@@ -445,12 +444,7 @@ begin
     and not gGameApp.Game.IsReplay) then
     Exit;
 
-  if gGameApp.Game.IsMPGameSpeedUpAllowed then
-    Speed := gGameApp.Game.GetDefaultMPGameSpeed
-  else
-    Speed := 1;
-
-  gGameApp.Game.SetGameSpeed(IfThen(chkSuperSpeed.Checked, 300, Speed), False);
+  gGameApp.Game.SetGameSpeed(IfThen(chkSuperSpeed.Checked, 300, gGameApp.Game.GetNormalGameSpeed), False);
 end;
 
 

--- a/src/KM_FormMain.pas
+++ b/src/KM_FormMain.pas
@@ -436,12 +436,21 @@ end;
 
 
 procedure TFormMain.chkSuperSpeedClick(Sender: TObject);
+var Speed: Single;
 begin
   if (gGameApp.Game = nil)
-  or (gGameApp.Game.IsMultiplayer and not MULTIPLAYER_SPEEDUP and not gGameApp.Game.IsReplay) then
+  or (gGameApp.Game.IsMultiplayer
+    and not gGameApp.Game.IsMPGameSpeedUpAllowed
+    and not MULTIPLAYER_SPEEDUP
+    and not gGameApp.Game.IsReplay) then
     Exit;
 
-  gGameApp.Game.SetGameSpeed(IfThen(chkSuperSpeed.Checked, 300, 1), False);
+  if gGameApp.Game.IsMPGameSpeedUpAllowed then
+    Speed := gGameApp.Game.GetDefaultMPGameSpeed
+  else
+    Speed := 1;
+
+  gGameApp.Game.SetGameSpeed(IfThen(chkSuperSpeed.Checked, 300, Speed), False);
 end;
 
 

--- a/src/KM_Game.pas
+++ b/src/KM_Game.pas
@@ -141,9 +141,7 @@ type
     property MissionMode: TKMissionMode read fMissionMode write fMissionMode;
     function GetNewUID: Integer;
     function GetNormalGameSpeed: Single;
-    function GetNormalMPGameSpeed: Single;
-    procedure SetNormalMPGameSpeed(aToggle: Boolean = False);
-    procedure SetGameSpeed(aSpeed: Single; aToggle: Boolean; aNormalSpeed: Single = 1);
+    procedure SetGameSpeed(aSpeed: Single; aToggle: Boolean);
     procedure StepOneFrame;
     function SaveName(const aName, aExt: UnicodeString; aMultiPlayer: Boolean): UnicodeString;
     procedure UpdateMultiplayerTeams;
@@ -527,7 +525,7 @@ begin
   fGameOptions.SpeedPT := fNetworking.NetGameOptions.SpeedPT;
   fGameOptions.SpeedAfterPT := fNetworking.NetGameOptions.SpeedAfterPT;
 
-  SetNormalMPGameSpeed;
+  SetGameSpeed(GetNormalGameSpeed, False);
 
   //Assign existing NetPlayers(1..N) to map players(0..N-1)
   for I := 1 to fNetworking.NetPlayers.Count do
@@ -1188,31 +1186,17 @@ end;
 function TKMGame.GetNormalGameSpeed: Single;
 begin
   if IsMultiplayer then
-    Result := GetNormalMPGameSpeed
-  else
+  begin
+    if IsPeaceTime then
+      Result := fGameOptions.SpeedPT
+    else
+      Result := fGameOptions.SpeedAfterPT;
+  end else
     Result := 1;
 end;
 
 
-function TKMGame.GetNormalMPGameSpeed: Single;
-begin
-  if IsPeaceTime then
-    Result := fGameOptions.SpeedPT
-  else
-    Result := fGameOptions.SpeedAfterPT;
-end;
-
-
-procedure TKMGame.SetNormalMPGameSpeed(aToggle: Boolean = False);
-begin
-  if IsPeaceTime then
-    SetGameSpeed(fGameOptions.SpeedPT, aToggle)
-  else
-    SetGameSpeed(fGameOptions.SpeedAfterPT, aToggle);
-end;
-
-
-procedure TKMGame.SetGameSpeed(aSpeed: Single; aToggle: Boolean; aNormalSpeed: Single = 1);
+procedure TKMGame.SetGameSpeed(aSpeed: Single; aToggle: Boolean);
 begin
   Assert(aSpeed > 0);
 
@@ -1227,7 +1211,7 @@ begin
 
   //Make the speed toggle between aNormalSpeed (1 by default) and desired value
   if (aSpeed = fGameSpeed) and aToggle then
-    fGameSpeed := aNormalSpeed
+    fGameSpeed := GetNormalGameSpeed
   else
     fGameSpeed := aSpeed;
 

--- a/src/KM_Game.pas
+++ b/src/KM_Game.pas
@@ -140,9 +140,10 @@ type
     property IsPaused: Boolean read fIsPaused write fIsPaused;
     property MissionMode: TKMissionMode read fMissionMode write fMissionMode;
     function GetNewUID: Integer;
-    function GetDefaultMPGameSpeed: Single;
-    procedure SetDefaultMPGameSpeed(aToggle: Boolean = False);
-    procedure SetGameSpeed(aSpeed: Single; aToggle: Boolean; aToggleSpeed: Single = 1);
+    function GetNormalGameSpeed: Single;
+    function GetNormalMPGameSpeed: Single;
+    procedure SetNormalMPGameSpeed(aToggle: Boolean = False);
+    procedure SetGameSpeed(aSpeed: Single; aToggle: Boolean; aNormalSpeed: Single = 1);
     procedure StepOneFrame;
     function SaveName(const aName, aExt: UnicodeString; aMultiPlayer: Boolean): UnicodeString;
     procedure UpdateMultiplayerTeams;
@@ -526,7 +527,7 @@ begin
   fGameOptions.SpeedPT := fNetworking.NetGameOptions.SpeedPT;
   fGameOptions.SpeedAfterPT := fNetworking.NetGameOptions.SpeedAfterPT;
 
-  SetDefaultMPGameSpeed;
+  SetNormalMPGameSpeed;
 
   //Assign existing NetPlayers(1..N) to map players(0..N-1)
   for I := 1 to fNetworking.NetPlayers.Count do
@@ -1184,7 +1185,16 @@ begin
 end;
 
 
-function TKMGame.GetDefaultMPGameSpeed: Single;
+function TKMGame.GetNormalGameSpeed: Single;
+begin
+  if IsMultiplayer then
+    Result := GetNormalMPGameSpeed
+  else
+    Result := 1;
+end;
+
+
+function TKMGame.GetNormalMPGameSpeed: Single;
 begin
   if IsPeaceTime then
     Result := fGameOptions.SpeedPT
@@ -1193,7 +1203,7 @@ begin
 end;
 
 
-procedure TKMGame.SetDefaultMPGameSpeed(aToggle: Boolean = False);
+procedure TKMGame.SetNormalMPGameSpeed(aToggle: Boolean = False);
 begin
   if IsPeaceTime then
     SetGameSpeed(fGameOptions.SpeedPT, aToggle)
@@ -1202,7 +1212,7 @@ begin
 end;
 
 
-procedure TKMGame.SetGameSpeed(aSpeed: Single; aToggle: Boolean; aToggleSpeed: Single = 1);
+procedure TKMGame.SetGameSpeed(aSpeed: Single; aToggle: Boolean; aNormalSpeed: Single = 1);
 begin
   Assert(aSpeed > 0);
 
@@ -1217,7 +1227,7 @@ begin
 
   //Make the speed toggle between aToggleSpeed (1 by default) and desired value
   if (aSpeed = fGameSpeed) and aToggle then
-    fGameSpeed := aToggleSpeed
+    fGameSpeed := aNormalSpeed
   else
     fGameSpeed := aSpeed;
 

--- a/src/KM_Game.pas
+++ b/src/KM_Game.pas
@@ -1225,7 +1225,7 @@ begin
     Exit;
   end;
 
-  //Make the speed toggle between aToggleSpeed (1 by default) and desired value
+  //Make the speed toggle between aNormalSpeed (1 by default) and desired value
   if (aSpeed = fGameSpeed) and aToggle then
     fGameSpeed := aNormalSpeed
   else

--- a/src/KM_Game.pas
+++ b/src/KM_Game.pas
@@ -140,8 +140,9 @@ type
     property IsPaused: Boolean read fIsPaused write fIsPaused;
     property MissionMode: TKMissionMode read fMissionMode write fMissionMode;
     function GetNewUID: Integer;
+    function GetDefaultMPGameSpeed: Single;
     procedure SetDefaultMPGameSpeed(aToggle: Boolean = False);
-    procedure SetGameSpeed(aSpeed: Single; aToggle: Boolean);
+    procedure SetGameSpeed(aSpeed: Single; aToggle: Boolean; aToggleSpeed: Single = 1);
     procedure StepOneFrame;
     function SaveName(const aName, aExt: UnicodeString; aMultiPlayer: Boolean): UnicodeString;
     procedure UpdateMultiplayerTeams;
@@ -1183,6 +1184,15 @@ begin
 end;
 
 
+function TKMGame.GetDefaultMPGameSpeed: Single;
+begin
+  if IsPeaceTime then
+    Result := fGameOptions.SpeedPT
+  else
+    Result := fGameOptions.SpeedAfterPT;
+end;
+
+
 procedure TKMGame.SetDefaultMPGameSpeed(aToggle: Boolean = False);
 begin
   if IsPeaceTime then
@@ -1192,7 +1202,7 @@ begin
 end;
 
 
-procedure TKMGame.SetGameSpeed(aSpeed: Single; aToggle: Boolean);
+procedure TKMGame.SetGameSpeed(aSpeed: Single; aToggle: Boolean; aToggleSpeed: Single = 1);
 begin
   Assert(aSpeed > 0);
 
@@ -1205,9 +1215,9 @@ begin
     Exit;
   end;
 
-  //Make the speed toggle between 1 and desired value
+  //Make the speed toggle between aToggleSpeed (1 by default) and desired value
   if (aSpeed = fGameSpeed) and aToggle then
-    fGameSpeed := 1
+    fGameSpeed := aToggleSpeed
   else
     fGameSpeed := aSpeed;
 
@@ -1231,6 +1241,9 @@ begin
   //Need to adjust the delay immediately in MP
   if IsMultiplayer and (fGameInputProcess <> nil) then
     TGameInputProcess_Multi(fGameInputProcess).AdjustDelay(fGameSpeed);
+
+  if Assigned(gGameApp.OnGameSpeedChange) then
+    gGameApp.OnGameSpeedChange(fGameSpeed);
 end;
 
 

--- a/src/KM_GameApp.pas
+++ b/src/KM_GameApp.pas
@@ -26,6 +26,7 @@ type
     fMainMenuInterface: TKMMainMenuInterface;
 
     fOnCursorUpdate: TIntegerStringEvent;
+    fOnGameSpeedChange: TSingleEvent;
 
     procedure GameLoadingStep(const aText: UnicodeString);
     procedure LoadGameAssets;
@@ -79,6 +80,8 @@ type
     procedure MouseUp(Button: TMouseButton; Shift: TShiftState; X,Y: Integer);
     procedure MouseWheel(Shift: TShiftState; WheelDelta: Integer; X,Y: Integer);
     procedure FPSMeasurement(aFPS: Cardinal);
+
+    property OnGameSpeedChange: TSingleEvent read fOnGameSpeedChange write fOnGameSpeedChange;
 
     procedure Render(aForPrintScreen: Boolean);
     procedure UpdateState(Sender: TObject);

--- a/src/KM_Main.pas
+++ b/src/KM_Main.pas
@@ -26,6 +26,9 @@ type
     procedure DoIdle(Sender: TObject; var Done: Boolean);
 
     procedure MapCacheUpdate;
+
+    procedure StatusBarText(aPanelIndex: Integer; const aText: UnicodeString);
+    procedure GameSpeedChange(aSpeed: Single);
   public
     constructor Create;
     destructor Destroy; override;
@@ -53,8 +56,6 @@ type
 
     function LockMutex: Boolean;
     procedure UnlockMutex;
-
-    procedure StatusBarText(aPanelIndex: Integer; const aText: UnicodeString); overload;
 
     property Resolutions: TKMResolutions read fResolutions;
     property Settings: TMainSettings read fMainSettings;
@@ -162,6 +163,12 @@ end;
 procedure TKMMain.StatusBarText(aPanelIndex: Integer; const aText: UnicodeString);
 begin
   fFormMain.StatusBar1.Panels[aPanelIndex].Text := aText;
+end;
+
+
+procedure TKMMain.GameSpeedChange(aSpeed: Single);
+begin
+  fFormMain.chkSuperSpeed.Checked := aSpeed = 300;
 end;
 
 
@@ -333,6 +340,7 @@ begin
                                 fFormLoading.LoadingStep,
                                 fFormLoading.LoadingText,
                                 StatusBarText);
+  gGameApp.OnGameSpeedChange := GameSpeedChange;
   gGameApp.AfterConstruction(aReturnToOptions);
 
   gLog.AddTime('ToggleFullscreen');

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -2821,7 +2821,7 @@ var
   LastAlert: TKMAlert;
   SelectId: Integer;
   SpecPlayerIndex: ShortInt;
-  ToggleSpeed: Single;
+  NormalSpeed: Single;
 begin
   if gGame.IsPaused and (fUIMode = umSP) then
   begin
@@ -2965,16 +2965,12 @@ begin
     or gGame.IsMPGameSpeedUpAllowed
     or MULTIPLAYER_SPEEDUP then
   begin
-
     // Game speed/pause: available in multiplayer mode if the only player left in the game
-    if gGame.IsMPGameSpeedUpAllowed then
-      ToggleSpeed := gGame.GetDefaultMPGameSpeed
-    else 
-      ToggleSpeed := 1;
-    if Key = gResKeys[SC_SPEEDUP_1].Key then gGame.SetGameSpeed(1, True, ToggleSpeed);
-    if Key = gResKeys[SC_SPEEDUP_2].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedMedium, True, ToggleSpeed);
-    if Key = gResKeys[SC_SPEEDUP_3].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedFast, True, ToggleSpeed);
-    if Key = gResKeys[SC_SPEEDUP_4].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedVeryFast, True, ToggleSpeed);
+    NormalSpeed := gGame.GetNormalGameSpeed;
+    if Key = gResKeys[SC_SPEEDUP_1].Key then gGame.SetGameSpeed(1, True, NormalSpeed);
+    if Key = gResKeys[SC_SPEEDUP_2].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedMedium, True, NormalSpeed);
+    if Key = gResKeys[SC_SPEEDUP_3].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedFast, True, NormalSpeed);
+    if Key = gResKeys[SC_SPEEDUP_4].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedVeryFast, True, NormalSpeed);
   end;
 
   // All the following keys don't work in Replay, because they alter game state

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -2821,6 +2821,7 @@ var
   LastAlert: TKMAlert;
   SelectId: Integer;
   SpecPlayerIndex: ShortInt;
+  ToggleSpeed: Single;
 begin
   if gGame.IsPaused and (fUIMode = umSP) then
   begin
@@ -2964,11 +2965,16 @@ begin
     or gGame.IsMPGameSpeedUpAllowed
     or MULTIPLAYER_SPEEDUP then
   begin
+
     // Game speed/pause: available in multiplayer mode if the only player left in the game
-    if Key = gResKeys[SC_SPEEDUP_1].Key then gGame.SetGameSpeed(1, False);
-    if Key = gResKeys[SC_SPEEDUP_2].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedMedium, True);
-    if Key = gResKeys[SC_SPEEDUP_3].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedFast, True);
-    if Key = gResKeys[SC_SPEEDUP_4].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedVeryFast, True);
+    if gGame.IsMPGameSpeedUpAllowed then
+      ToggleSpeed := gGame.GetDefaultMPGameSpeed
+    else 
+      ToggleSpeed := 1;
+    if Key = gResKeys[SC_SPEEDUP_1].Key then gGame.SetGameSpeed(1, True, ToggleSpeed);
+    if Key = gResKeys[SC_SPEEDUP_2].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedMedium, True, ToggleSpeed);
+    if Key = gResKeys[SC_SPEEDUP_3].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedFast, True, ToggleSpeed);
+    if Key = gResKeys[SC_SPEEDUP_4].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedVeryFast, True, ToggleSpeed);
   end;
 
   // All the following keys don't work in Replay, because they alter game state

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -2821,7 +2821,6 @@ var
   LastAlert: TKMAlert;
   SelectId: Integer;
   SpecPlayerIndex: ShortInt;
-  NormalSpeed: Single;
 begin
   if gGame.IsPaused and (fUIMode = umSP) then
   begin
@@ -2966,11 +2965,10 @@ begin
     or MULTIPLAYER_SPEEDUP then
   begin
     // Game speed/pause: available in multiplayer mode if the only player left in the game
-    NormalSpeed := gGame.GetNormalGameSpeed;
-    if Key = gResKeys[SC_SPEEDUP_1].Key then gGame.SetGameSpeed(1, True, NormalSpeed);
-    if Key = gResKeys[SC_SPEEDUP_2].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedMedium, True, NormalSpeed);
-    if Key = gResKeys[SC_SPEEDUP_3].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedFast, True, NormalSpeed);
-    if Key = gResKeys[SC_SPEEDUP_4].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedVeryFast, True, NormalSpeed);
+    if Key = gResKeys[SC_SPEEDUP_1].Key then gGame.SetGameSpeed(1, True);
+    if Key = gResKeys[SC_SPEEDUP_2].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedMedium, True);
+    if Key = gResKeys[SC_SPEEDUP_3].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedFast, True);
+    if Key = gResKeys[SC_SPEEDUP_4].Key then gGame.SetGameSpeed(gGameApp.GameSettings.SpeedVeryFast, True);
   end;
 
   // All the following keys don't work in Replay, because they alter game state


### PR DESCRIPTION
Used for toggle.

Also added support for x300 speed in MP, if allowed.

Also fixed small bug with checked x300 checkbox, when speed was changed from x300 to lower value by speedup hotkey.