### PR TITLE
For multi monitor systems added new parameter to set border scroll area width on the second monitor

### DIFF
--- a/src/KM_Main.pas
+++ b/src/KM_Main.pas
@@ -8,6 +8,8 @@ uses
   {$IFDEF USE_MAD_EXCEPT}, KM_Exceptions{$ENDIF};
 
 type
+  TRectArray = array of TRect;
+
   TKMMain = class
   private
     fFormMain: TFormMain;
@@ -46,6 +48,7 @@ type
     property FormMain: TFormMain read fFormMain;
 
     procedure ApplyCursorRestriction;
+    procedure GetMonitorsBounds(out MonitorsBounds: TRectArray);
     function GetScreenBounds(out Bounds: TRect): Boolean;
     function IsFormActive: Boolean;
     function ClientRect: TRect;
@@ -451,6 +454,22 @@ begin
 end;
 
 
+procedure TKMMain.GetMonitorsBounds(out MonitorsBounds: TRectArray);
+var I: Integer;
+begin
+  SetLength(MonitorsBounds, Screen.MonitorCount);
+
+  for I := 0 to Screen.MonitorCount - 1 do
+  begin
+    MonitorsBounds[I] := Classes.Rect(-1,-1,-1,-1);
+    MonitorsBounds[I].Left  := Screen.Monitors[I].Left;
+    MonitorsBounds[I].Right := Screen.Monitors[I].Width + Screen.Monitors[I].Left;
+    MonitorsBounds[I].Top   := Screen.Monitors[I].Top;
+    MonitorsBounds[I].Bottom:= Screen.Monitors[I].Height + Screen.Monitors[I].Top;
+  end;
+end;
+
+
 //Can be invalid very breifly if you change resolutions (this is possible in Windowed mode)
 function TKMMain.GetScreenBounds(out Bounds: TRect): Boolean;
 var I: Integer;
@@ -461,7 +480,7 @@ begin
   //Maximized is a special case, it can only be on one monitor. This is required because when maximized form.left = -9 (on Windows 7 anyway)
   if fFormMain.WindowState = wsMaximized then
   begin
-    for I:=0 to Screen.MonitorCount-1 do
+    for I := 0 to Screen.MonitorCount - 1 do
       //Find the monitor with the left closest to the left of the form
       if (I = 0) or
          ((abs(fFormMain.Left - Screen.Monitors[I].Left) <= abs(fFormMain.Left - Bounds.Left)) and
@@ -475,7 +494,7 @@ begin
       end;
   end
   else
-    for I:=0 to Screen.MonitorCount-1 do
+    for I := 0 to Screen.MonitorCount - 1 do
       //See if our form is within the boundaries of this monitor (I.e. when it is not outside the boundaries)
       if not ((fFormMain.Left               >= Screen.Monitors[I].Width + Screen.Monitors[I].Left) or
               (fFormMain.Width + fFormMain.Left <= Screen.Monitors[I].Left) or

--- a/src/KM_Settings.pas
+++ b/src/KM_Settings.pas
@@ -99,6 +99,8 @@ type
     fReplayAutopause: Boolean;
     fBrightness: Byte;
     fScrollSpeed: Byte;
+    //For multi monitor systems: scroll border area width, which is located on 2nd (other) monitor
+    fSecondMonitorScrollAreaWidth: Integer;
     fAlphaShadows: Boolean;
     fLoadFullFonts: Boolean;
     fLocale: AnsiString;
@@ -151,6 +153,7 @@ type
     procedure SetReplayAutopause(aValue: Boolean);
     procedure SetBrightness(aValue: Byte);
     procedure SetScrollSpeed(aValue: Byte);
+    procedure SetSecondMonitorScrollAreaWidth(aValue: Integer);
     procedure SetAlphaShadows(aValue: Boolean);
     procedure SetLoadFullFonts(aValue: Boolean);
     procedure SetLocale(aLocale: AnsiString);
@@ -205,6 +208,7 @@ type
     property ReplayAutopause: Boolean read fReplayAutopause write SetReplayAutopause;
     property Brightness: Byte read fBrightness write SetBrightness;
     property ScrollSpeed: Byte read fScrollSpeed write SetScrollSpeed;
+    property SecondMonitorScrollAreaWidth: Integer read fSecondMonitorScrollAreaWidth write SetSecondMonitorScrollAreaWidth;
     property AlphaShadows: Boolean read fAlphaShadows write SetAlphaShadows;
     property LoadFullFonts: Boolean read fLoadFullFonts write SetLoadFullFonts;
     property Locale: AnsiString read fLocale write SetLocale;
@@ -440,6 +444,10 @@ begin
     fAutosave       := F.ReadBool   ('Game', 'Autosave',       True); //Should be ON by default
     fReplayAutopause:= F.ReadBool   ('Game', 'ReplayAutopause', False); //Disabled by default
     fScrollSpeed    := F.ReadInteger('Game', 'ScrollSpeed',    10);
+
+    //By default set too big value, so no restriction will be applied while scrolling
+    fSecondMonitorScrollAreaWidth := Max(0, F.ReadInteger('Game', 'SecondMonitorScrollAreaWidth', 10000)); //Do not allow negative values
+
     fLocale         := AnsiString(F.ReadString ('Game', 'Locale', UnicodeString(DEFAULT_LOCALE)));
     fSpeedPace      := F.ReadInteger('Game', 'SpeedPace',      100);
     fSpeedMedium    := F.ReadFloat('Game', 'SpeedMedium',    3);
@@ -517,6 +525,7 @@ begin
     F.WriteBool   ('Game','Autosave',        fAutosave);
     F.WriteBool   ('Game','ReplayAutopause', fReplayAutopause);
     F.WriteInteger('Game','ScrollSpeed',     fScrollSpeed);
+    F.WriteInteger('Game','SecondMonitorScrollAreaWidth', fSecondMonitorScrollAreaWidth);
     F.WriteString ('Game','Locale',          UnicodeString(fLocale));
     F.WriteInteger('Game','SpeedPace',       fSpeedPace);
     F.WriteFloat('Game','SpeedMedium',       fSpeedMedium);
@@ -730,6 +739,13 @@ end;
 procedure TGameSettings.SetScrollSpeed(aValue: Byte);
 begin
   fScrollSpeed := aValue;
+  Changed;
+end;
+
+
+procedure TGameSettings.SetSecondMonitorScrollAreaWidth(aValue: Integer);
+begin
+  fSecondMonitorScrollAreaWidth := aValue;
   Changed;
 end;
 


### PR DESCRIPTION
This PR fixes bug from our buglist:

> On 2 display setup, the game should not scroll the map if cursor is on the second display (windowed or fullscreen)

Difference is that you can set 2sn monitor scroll area width in ini for better game experience (without it its almost impossible to scroll with mouse to left or to right, depends of window/monitor position).

This case is not very popular, so adding this parameter in ini is good enought.

Currently we apply cursor restrictions when in Fullscreen mode, so this PR work only for window mode. After removing this restrictions in another PR it will work in fullscreen mode too.

I decided to add new parameter, because different users could expect different behaviour. 
One may want to have no restrictions at all (current and default behaviour) - most convinient way of mouse scroll on multi monitor systems.
Other may want to have full restrictions and use arrow keys for scrolling
And someone can choose something in between - f.e. if you set 100-200px, then it will be possible to scroll with mouse and also use your second monitor.

Could be usefull for streamers also.