### PR TITLE
Way to fix annoying group formation changes when warriors join that group.

### DIFF
--- a/src/units/KM_UnitGroups.pas
+++ b/src/units/KM_UnitGroups.pas
@@ -42,6 +42,7 @@ type
     fGroupType: TGroupType;
     fDisableHungerMessage: Boolean;
     fBlockOrders: Boolean;
+    fManualFormation: Boolean;
 
     fOrder: TKMGroupOrder; //Remember last order incase we need to repeat it (e.g. to joined members)
     fOrderLoc: TKMPointDir; //Dir is the direction to face after order
@@ -138,6 +139,7 @@ type
     property Order: TKMGroupOrder read fOrder;
     property DisableHungerMessage: Boolean read fDisableHungerMessage write fDisableHungerMessage;
     property BlockOrders: Boolean read fBlockOrders write fBlockOrders;
+    property ManualFormation: Boolean read fManualFormation write fManualFormation;
     property FlagPositionF: TKMPointF read GetFlagPositionF;
     property FlagColor: Cardinal read GetFlagColor;
     function IsFlagRenderBeforeUnit: Boolean;
@@ -333,7 +335,8 @@ begin
   LoadStream.Read(fTimeSinceHungryReminder);
   LoadStream.Read(fUnitsPerRow);
   LoadStream.Read(fDisableHungerMessage);
-  Loadstream.Read(fBlockOrders);
+  LoadStream.Read(fBlockOrders);
+  LoadStream.Read(fManualFormation);
 end;
 
 
@@ -420,6 +423,7 @@ begin
   SaveStream.Write(fUnitsPerRow);
   SaveStream.Write(fDisableHungerMessage);
   SaveStream.Write(fBlockOrders);
+  SaveStream.Write(fManualFormation);
 end;
 
 
@@ -1148,6 +1152,8 @@ begin
 
   SetUnitsPerRow(Max(fUnitsPerRow + aColumnsChange, 0));
 
+  ManualFormation := True;
+
   OrderRepeat;
 end;
 
@@ -1842,7 +1848,9 @@ begin
                      Result := gHands[aUnit.Owner].UnitGroups.GetGroupByMember(LinkUnit);
                      Result.AddMember(aUnit);
                      //Form a square (rather than a long snake like in TSK/TPR)
-                     Result.UnitsPerRow := Ceil(Sqrt(Result.Count));
+                     //but don't change formation if player decided to set it manually
+                     if not Result.ManualFormation then
+                       Result.UnitsPerRow := Ceil(Sqrt(Result.Count));
                      Result.OrderRepeat;
                    end
                    else


### PR DESCRIPTION
From buglist:

> When units exit Barracks and auto-join another group, they change that groups formation

Just don't change formation if player decided to set it manually.