### PR TITLE
Update position in sp game list on maped game save

### DIFF
--- a/src/KM_Game.pas
+++ b/src/KM_Game.pas
@@ -923,6 +923,7 @@ begin
       mfSP:       begin
                     gGameApp.GameSettings.MenuMapEdSPMapCRC := MapInfo.CRC;
                     gGameApp.GameSettings.MenuMapEdMapType := 0;
+                    gGameApp.GameSettings.MenuSPMapCRC := MapInfo.CRC;
                   end;
       mfMP,mfDL:  begin
                     gGameApp.GameSettings.MenuMapEdMPMapCRC := MapInfo.CRC;


### PR DESCRIPTION
Could be usufull for mapmakers, when they edit SP map (or campaign map, which is usually edited as SP map). Then if they want to test their changes map will be already selected in list.

For all other players it could not add any difficulties, because it not often to play same SP map all the time and also they probably do not use MapEd so much.

If mapmakers want to check their MP map changes, they could use 'favorite maps' feature - they are updated on maped resave