### PR TITLE
Unit group: feed or split command should not cancel group previous order

### DIFF
--- a/src/units/KM_UnitGroups.pas
+++ b/src/units/KM_UnitGroups.pas
@@ -1241,8 +1241,8 @@ begin
   case fOrder of
     goNone:         OrderHalt(False);
     goWalkTo:       OrderWalk(fOrderLoc.Loc, False);
-    goAttackHouse:  if OrderTargetHouse <> nil then OrderAttackHouse(aGroup.OrderTargetHouse, False);
-    goAttackUnit:   if OrderTargetUnit <> nil then OrderAttackUnit(aGroup.OrderTargetUnit, False);
+    goAttackHouse:  if aGroup.OrderTargetHouse <> nil then OrderAttackHouse(aGroup.OrderTargetHouse, False);
+    goAttackUnit:   if aGroup.OrderTargetUnit <> nil then OrderAttackUnit(aGroup.OrderTargetUnit, False);
     goStorm:        ;
   end;
 end;


### PR DESCRIPTION
If group has some order (walk/attack unit/house) then it is usually continue it after some group command was initiated (change rows count, turn left or right, link). But for some reason group get halt order on feed and split command. Its very unpleasant - player send his troops to some point, then he wanted to feed them or split - and group stop going to that point, making formation instead.

This PR fixes this issue.