### PR TITLE
Fixed return of color through PlayerColorText function in dynamic scripts

### DIFF
--- a/src/scripting/KM_ScriptingStates.pas
+++ b/src/scripting/KM_ScriptingStates.pas
@@ -1051,8 +1051,7 @@ function TKMScriptStates.PlayerColorText(aPlayer: Byte): AnsiString;
 begin
   try
     if InRange(aPlayer, 0, gHands.Count - 1) and (gHands[aPlayer].Enabled) then
-      Result := IntToHex(gHands[aPlayer].FlagColor and $00FFFFFF, 6)
-      //Result := AnsiString(Format('%.6x', [FlagColorToTextColor(gHands[aPlayer].FlagColor) and $FFFFFF]))
+      Result := IntToHex(gHands[aPlayer].FlagColor and $FFFFFF, 6)
     else
     begin
       Result := '';

--- a/src/scripting/KM_ScriptingStates.pas
+++ b/src/scripting/KM_ScriptingStates.pas
@@ -1051,7 +1051,8 @@ function TKMScriptStates.PlayerColorText(aPlayer: Byte): AnsiString;
 begin
   try
     if InRange(aPlayer, 0, gHands.Count - 1) and (gHands[aPlayer].Enabled) then
-      Result := AnsiString(Format('%.6x', [FlagColorToTextColor(gHands[aPlayer].FlagColor) and $FFFFFF]))
+      Result := IntToHex(gHands[aPlayer].FlagColor and $00FFFFFF, 6)
+      //Result := AnsiString(Format('%.6x', [FlagColorToTextColor(gHands[aPlayer].FlagColor) and $FFFFFF]))
     else
     begin
       Result := '';


### PR DESCRIPTION
PlayerColorText function returns the wrong shade of color
More details on the screenshot:
![image](https://cloud.githubusercontent.com/assets/17384156/23595558/98534658-0244-11e7-8963-7d604c74bbe4.png)
1 Variant - Result := IntToHex(aColor and $00FFFFFF, 6);
2 Variant - Result := AnsiString(Format('%.6x', [FlagColorToTextColor(aColor) and $FFFFFF]));