### PR TITLE
Updating or adding a dynamic script analogue PlayerColorText

### DIFF
--- a/src/scripting/KM_Scripting.pas
+++ b/src/scripting/KM_Scripting.pas
@@ -300,7 +300,7 @@ begin
       RegisterMethod('function PeaceTime: Cardinal');
 
       RegisterMethod('function PlayerAllianceCheck(aPlayer1, aPlayer2: Byte): Boolean');
-      RegisterMethod('function PlayerColorText(aPlayer: Byte): AnsiString');
+      RegisterMethod('function PlayerColorText(aPlayer: Byte; bLight: Boolean): AnsiString');
       RegisterMethod('function PlayerDefeated(aPlayer: Byte): Boolean');
       RegisterMethod('function PlayerEnabled(aPlayer: Byte): Boolean');
       RegisterMethod('function PlayerGetAllGroups(aPlayer: Byte): TIntegerArray');

--- a/src/scripting/KM_ScriptingStates.pas
+++ b/src/scripting/KM_ScriptingStates.pas
@@ -1045,7 +1045,7 @@ begin
 end;
 
 
-//* Version: 4758
+//* Version: 4758 Update 7000+
 //* Get players color as text in hex format
 //* Result: Player color
 function TKMScriptStates.PlayerColorText(aPlayer: Byte;
@@ -1059,7 +1059,7 @@ begin
       if bLight then
         Result := AnsiString(Format('%.6x', [FlagColorToTextColor(gHands[aPlayer].FlagColor) and $FFFFFF]))
       else
-        Result := IntToHex(gHands[aPlayer].FlagColor and $FFFFFF, 6)
+        Result := AnsiString(IntToHex(gHands[aPlayer].FlagColor and $FFFFFF, 6))
     end
     else
     begin

--- a/src/scripting/KM_ScriptingStates.pas
+++ b/src/scripting/KM_ScriptingStates.pas
@@ -83,7 +83,7 @@ type
     function PeaceTime: Cardinal;
 
     function PlayerAllianceCheck(aPlayer1, aPlayer2: Byte): Boolean;
-    function PlayerColorText(aPlayer: Byte): AnsiString;
+    function PlayerColorText(aPlayer: Byte; bLight: Boolean = True): AnsiString;
     function PlayerDefeated(aPlayer: Byte): Boolean;
     function PlayerEnabled(aPlayer: Byte): Boolean;
     function PlayerGetAllUnits(aPlayer: Byte): TIntegerArray;
@@ -543,6 +543,7 @@ begin
     raise;
   end;
 end;
+
 
 
 //* Version: 6328
@@ -1047,14 +1048,18 @@ end;
 //* Version: 4758
 //* Get players color as text in hex format
 //* Result: Player color
-function TKMScriptStates.PlayerColorText(aPlayer: Byte): AnsiString;
+function TKMScriptStates.PlayerColorText(aPlayer: Byte;
+  bLight: Boolean): AnsiString;
 begin
   try
     if InRange(aPlayer, 0, gHands.Count - 1) and (gHands[aPlayer].Enabled) then
     begin
       //Use FlagColorToTextColor to desaturate and lighten the text so all player colours are
       //readable on a variety of backgrounds
-      Result := AnsiString(Format('%.6x', [FlagColorToTextColor(gHands[aPlayer].FlagColor) and $FFFFFF]))
+      if bLight then
+        Result := AnsiString(Format('%.6x', [FlagColorToTextColor(gHands[aPlayer].FlagColor) and $FFFFFF]))
+      else
+        Result := IntToHex(gHands[aPlayer].FlagColor and $FFFFFF, 6)
     end
     else
     begin
@@ -1066,7 +1071,6 @@ begin
     raise;
   end;
 end;
-
 
 //* Version: 5057
 //* Will be false if nobody selected that location in multiplayer


### PR DESCRIPTION
At this stage, I just updated the function of the TextbookText so that it returns not only the clarified color but also the original + so that the function remains compatible with the old scripts.
If you do not like it, I can add a separate one.
If you say that it's not obvious then In the wiki you can update

Here's what it looks like:
![2017-03-08](https://cloud.githubusercontent.com/assets/17384156/23708404/9849d7ae-0437-11e7-92c2-9395255cfe31.png)
Using:
```
procedure OnMissionStart;
begin
	Actions.OverlayTextSet(0, '[$'+States.PlayerColorText(0)+']1 Variant|[$'+States.PlayerColorText(0, false)+']2 Variant');
end;
```