### PR TITLE
Fix: Update saved SP game list saved selected map position CRC if we resave this map

### DIFF
--- a/src/KM_Game.pas
+++ b/src/KM_Game.pas
@@ -919,6 +919,9 @@ begin
       mfSP:       begin
                     gGameApp.GameSettings.MenuMapEdSPMapCRC := MapInfo.CRC;
                     gGameApp.GameSettings.MenuMapEdMapType := 0;
+                    // Update saved SP game list saved selected map position CRC if we resave this map
+                    if fGameMapCRC = gGameApp.GameSettings.MenuSPMapCRC then
+                      gGameApp.GameSettings.MenuSPMapCRC := MapInfo.CRC;
                   end;
       mfMP,mfDL:  begin
                     gGameApp.GameSettings.MenuMapEdMPMapCRC := MapInfo.CRC;


### PR DESCRIPTION
In #328 I agreed that adding new button to MapEd for to test map from MapEd directly would be nice. 

But also if map was previously selected on SP maps list in SP game menu, then if we edit it in MapEd selection will be lost due to CRC update. So I think its good to fix it, to avoid losing selection on map edit.