### PR TITLE
Bugfix: game crash, when create local server, allow to post net logs to chat, then close game window

### DIFF
--- a/src/gui/pages_menu/KM_GUIMenuLobby.pas
+++ b/src/gui/pages_menu/KM_GUIMenuLobby.pas
@@ -2147,10 +2147,13 @@ end;
 
 procedure TKMMenuLobby.Lobby_OnMessage(const aText: UnicodeString);
 begin
-  if gGameApp.GameSettings.FlashOnMessage then
-    gMain.FlashingStart;
+  if (gGameApp <> nil) and (gGameApp.GameSettings <> nil) then
+  begin
+    if gGameApp.GameSettings.FlashOnMessage then
+      gMain.FlashingStart;
 
-  Memo_LobbyPosts.Add(aText);
+    Memo_LobbyPosts.Add(aText);
+  end;
 end;
 
 


### PR DESCRIPTION
Dedicated server post logs, when game app is during destroy. Then try to post logs in chat, and fail because GameSettings are already nil.