### PR TITLE
Controls: Numedit improvements and refactoring

### DIFF
--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -485,6 +485,7 @@ type
   end;
 
 
+  //Selectable Edit - Basic Edit class with selection available
   TKMSelectableEdit = class(TKMControl)
   private
     fFont: TKMFont;
@@ -3375,7 +3376,6 @@ procedure TKMNumericEdit.SetValue(aValue: Integer);
 begin
   fValue := EnsureRange(aValue, ValueMin, ValueMax);
   fText := IntToStr(fValue);
-  SetCursorPos(GetMaxLength);
 
   //External Value assignment should not generate OnChange event
 end;

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -7010,7 +7010,8 @@ end;
 
 
 //Check if control is covered by other controls or not
-//We assume that control is covered if any of his 4 angles is covered
+//We assume that control is covered if any of his 4 corners is covered
+//For corners used actual corners with 1 px offset inside to solve border collisions
 //Use Self coordinates to check, because some controls can contain other sub-controls (f.e. TKMNumericEdit)
 function TKMMasterControl.IsCtrlCovered(aCtrl: TKMControl): Boolean;
 begin

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -3223,20 +3223,30 @@ end;
 
 
 procedure TKMNumericEdit.ClickHold(Sender: TObject; Button: TMouseButton; var aHandled: Boolean);
-var Inc: Integer;
+var Amt: Integer;
+    Shift: TShiftState;
 begin
   inherited;
   aHandled := True;
+  Shift := [];
   case Button of
-    mbLeft:   Inc := 1;
-    mbRight:  Inc := 10;
-    else      Inc := 0;
+    mbLeft:   Include(Shift, ssLeft);
+    mbRight:  Include(Shift, ssRight);
   end;
+
+  if GetKeyState(VK_SHIFT) < 0 then
+    Include(Shift, ssShift);
+
+  Amt := GetMultiplicator(Shift);
+
   if Sender = fButtonDec then
-    Value := Value - Inc
+    Value := Value - Amt
   else
   if Sender = fButtonInc then
-    Value := Value + Inc
+    Value := Value + Amt;
+
+  if (Amt <> 0) and Assigned(OnChange) then
+    OnChange(Self);
 end;
 
 
@@ -3292,6 +3302,9 @@ begin
   if WheelDelta < 0 then Value := Value - 1 - 9*Byte(GetKeyState(VK_SHIFT) < 0);
 
   Focus;
+
+  if Assigned(OnChange) then
+    OnChange(Self);
 end;
 
 

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -6,7 +6,7 @@ uses
     {$IFDEF Unix} LCLIntf, LCLType, {$ENDIF}
     Classes, Controls,  Math, SysUtils, StrUtils, Clipbrd,
     KromUtils, KromOGLUtils, KM_Defaults, KM_Points, KM_CommonTypes, KM_Pics,
-    KM_RenderUI, KM_ResFonts, KM_Minimap, KM_Viewport, KM_Log;
+    KM_RenderUI, KM_ResFonts, KM_Minimap, KM_Viewport;
 
 type
   TNotifyEventShift = procedure(Sender: TObject; Shift: TShiftState) of object;
@@ -2101,15 +2101,9 @@ end;
 
 procedure TKMPanel.UpdateState(aTickCount: Cardinal);
 var I: Integer;
-    Updated: String;
 begin
-  Updated := IntToStr(aTickCount) + ': ';
   for I := 0 to ChildCount - 1 do
-  begin
     Childs[I].UpdateState(aTickCount);
-    Updated := Updated + IntToStr(Childs[I].fID) + ',';
-  end;
-  gLog.AddTime(Updated);
 end;
 
 

--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -488,7 +488,6 @@ type
   TKMSelectableEdit = class(TKMControl)
   private
     fFont: TKMFont;
-    fText: UnicodeString;
     fLeftIndex: Integer; //The position of the character shown left-most when text does not fit
 
     fCursorPos: Integer;
@@ -509,6 +508,7 @@ type
     procedure FocusSelectableEdit(aFocused: Boolean);
     procedure ControlMouseDown(Sender: TObject; Shift: TShiftState);
   protected
+    fText: UnicodeString;
     function GetMaxLength: Word; virtual; abstract;
     function IsCharValid(aChar: WideChar): Boolean; virtual; abstract;
     procedure ValidateText; virtual; abstract;
@@ -838,8 +838,9 @@ type
     function GetColumnIndex(X: Integer): Integer;
     function GetColumn(aIndex: Integer): TKMListHeaderColumn;
     procedure ClearColumns;
-    procedure DoClick(X,Y: Integer; Shift: TShiftState; Button: TMouseButton); override;
     function GetColumnWidth(aIndex: Integer): Integer;
+  protected
+    procedure DoClick(X,Y: Integer; Shift: TShiftState; Button: TMouseButton); override;
   public
     BackAlpha: Single; //Alpha of background
     EdgeAlpha: Single; //Alpha of background outline
@@ -3026,7 +3027,7 @@ end;
 
 procedure TKMSelectableEdit.PaintSelection;
 var
-  RText, BeforeSelectionText, SelectionText: UnicodeString;
+  BeforeSelectionText, SelectionText: UnicodeString;
   BeforeSelectionW, SelectionW: Integer;
 begin
   if HasSelection then
@@ -3159,8 +3160,8 @@ end;
 procedure TKMEdit.Paint;
 var
   Col: TColor4;
-  RText, BeforeSelectionText, SelectionText: UnicodeString;
-  OffX, BeforeSelectionW, SelectionW: Integer;
+  RText: UnicodeString;
+  OffX: Integer;
 begin
   inherited;
 
@@ -3239,7 +3240,6 @@ end;
 
 
 function TKMNumericEdit.KeyDown(Key: Word; Shift: TShiftState): Boolean;
-var Inc: Integer;
 begin
   Result := KeyEventHandled(Key, Shift);
   inherited KeyDown(Key, Shift);
@@ -3367,7 +3367,7 @@ end;
 
 function TKMNumericEdit.IsCharValid(Key: WideChar): Boolean;
 begin
-  Result := Key in ['0'..'9'];
+  Result := SysUtils.CharInSet(Key, ['0'..'9']);
 end;
 
 

--- a/src/gui/KM_InterfaceDefaults.pas
+++ b/src/gui/KM_InterfaceDefaults.pas
@@ -61,7 +61,7 @@ type
     procedure MouseUp(Button: TMouseButton; Shift: TShiftState; X,Y: Integer); virtual; abstract;
     procedure MouseWheel(Shift: TShiftState; WheelDelta: Integer; X,Y: Integer); virtual;
     procedure Resize(X,Y: Word); virtual;
-    procedure UpdateState(aTickCount: Cardinal); virtual; abstract;
+    procedure UpdateState(aTickCount: Cardinal); virtual;
     procedure Paint; virtual;
   end;
 
@@ -115,6 +115,13 @@ procedure TKMUserInterfaceCommon.Resize(X, Y: Word);
 begin
   Panel_Main.Width := X;
   Panel_Main.Height := Y;
+end;
+
+
+procedure TKMUserInterfaceCommon.UpdateState(aTickCount: Cardinal);
+begin
+  inherited;
+  fMyControls.UpdateState(aTickCount);
 end;
 
 

--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -3722,6 +3722,7 @@ var
   I: Integer;
   Rect: TKMRect;
 begin
+  inherited;
   // Update minimap every 1000ms
   if aTickCount mod 10 = 0 then
     fMinimap.Update(False);

--- a/src/gui/KM_InterfaceMainMenu.pas
+++ b/src/gui/KM_InterfaceMainMenu.pas
@@ -367,6 +367,7 @@ end;
 //Should update anything we want to be updated, obviously
 procedure TKMMainMenuInterface.UpdateState(aTickCount: Cardinal);
 begin
+  inherited;
   fMenuLobby.UpdateState;
   fMenuMapEditor.UpdateState;
   fMenuLoad.UpdateState;

--- a/src/gui/KM_InterfaceMapEditor.pas
+++ b/src/gui/KM_InterfaceMapEditor.pas
@@ -358,6 +358,7 @@ end;
 //Should update any items changed by game (resource counts, hp, etc..)
 procedure TKMapEdInterface.UpdateState(aTickCount: Cardinal);
 begin
+  inherited;
   //Update minimap every 1000ms
   if aTickCount mod 10 = 0 then
     fMinimap.Update(False);


### PR DESCRIPTION
1. Added new abstract control: TKMSelectableEdit. Its parent control for TKMEdit and TKMNumericEdit. Basically I just moved code, related to selecting in edit from TKMEdit to TKMSelectableEdit and reused it for TKMNumericEdit.
2. Added change NumEdit value on mouse wheel.
3. Added new ClickHold event for controls. For numeric edit its used for inc/dec value. Also we will be able to add implementaion for next task in our buglist:
'Clicking and holding on the add/subtract buttons in weapons workshops could increase the number to save repeated clicking'.