### PR TITLE
BugFix: demolish wrong house by using house hotkey

### DIFF
--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -2604,6 +2604,7 @@ begin
       gMySpectator.Selected := gHands.GetHouseByUID(fSelection[aId]);
       if gMySpectator.Selected <> nil then
       begin
+        fGuiGameHouse.AskDemolish := False; //Close AskDemolish dialog, if was open by setting AskDemolish flag to False
         if TKMHouse(gMySpectator.Selected).IsDestroyed then
         begin
           gMySpectator.Selected := nil; // Don't select destroyed houses

--- a/src/gui/pages_game/KM_GUIGameHouse.pas
+++ b/src/gui/pages_game/KM_GUIGameHouse.pas
@@ -9,7 +9,6 @@ uses
 type
   TKMGUIGameHouse = class
   private
-    fAskDemolish: Boolean;
     fLastSchoolUnit: Byte;  //Last unit that was selected in School, global for all schools player owns
     fLastBarracksUnit: Byte; //Last unit that was selected in Barracks, global for all barracks player owns
 
@@ -84,6 +83,7 @@ type
       Radio_Woodcutter: TKMRadioGroup;
       Button_Woodcutter: TKMButtonFlat;
   public
+    AskDemolish: Boolean;
     OnHouseDemolish: TEvent;
 
     constructor Create(aParent: TKMPanel);
@@ -389,7 +389,7 @@ end;
 
 procedure TKMGUIGameHouse.Show(aHouse: TKMHouse);
 begin
-  Show(aHouse, fAskDemolish);
+  Show(aHouse, AskDemolish);
 end;
 
 
@@ -397,7 +397,7 @@ procedure TKMGUIGameHouse.Show(aHouse: TKMHouse; aAskDemolish: Boolean);
 const LineAdv = 25; //Each new Line is placed ## pixels after previous
 var I,RowRes,Base,Line:integer; Res: TWareType;
 begin
-  fAskDemolish := aAskDemolish;
+  AskDemolish := aAskDemolish;
 
   //Hide all House sub-pages
   for I := 0 to Panel_House.ChildCount - 1 do
@@ -419,7 +419,7 @@ begin
   HealthBar_House.Caption   := inttostr(round(aHouse.GetHealth))+'/'+inttostr(gRes.Houses[aHouse.HouseType].MaxHealth);
   HealthBar_House.Position  := aHouse.GetHealth / gRes.Houses[aHouse.HouseType].MaxHealth;
 
-  if fAskDemolish then
+  if AskDemolish then
   begin
     for I := 0 to Panel_House.ChildCount - 1 do
       Panel_House.Childs[I].Hide; //hide all
@@ -651,7 +651,7 @@ begin
     Panel_House.Hide; //Simpliest way to reset page and ShownHouse
   end;
 
-  fAskDemolish := False;
+  AskDemolish := False;
   OnHouseDemolish; //Return to build menu
 end;
 


### PR DESCRIPTION
Bug description: 
1st set a hotkey to a school
2nd start a deleteing process on a coalmine but when the question is popping 'Do you really want to delete the building' then
3rd press the hotkey to the school and then the question will adressed to the school
4th now press i want to delete the building

Result is the scholl destroyed and not the coalmine.

A solution could be: If the question is up then the hotkey should overwrite the question with say 'no' and open the school or any hotkeyed building without destroying.