### PR TITLE
BugFix: Replay/Spectating - have to update player interface on player switch (f.e. FOW, Overlay) at one point in code

### DIFF
--- a/src/gui/KM_InterfaceGamePlay.pas
+++ b/src/gui/KM_InterfaceGamePlay.pas
@@ -144,6 +144,7 @@ type
     procedure Replay_JumpToPlayer(aPlayerIndex: Integer);
     procedure Replay_ViewPlayer(aPlayerIndex: Integer);
     procedure Replay_ListDoubleClick(Sender: TObject);
+    procedure Replay_UpdatePlayerInterface;
   protected
     Sidebar_Top: TKMImage;
     Sidebar_Middle: TKMImage;
@@ -1822,6 +1823,7 @@ begin
   Button_ReplayResume.Enabled := not aPaused;
 end;
 
+
 procedure TKMGamePlayInterface.Replay_JumpToPlayer(aPlayerIndex: Integer);
 var LastSelectedObj: TObject;
 begin
@@ -1846,7 +1848,9 @@ begin
       fViewport.Position := KMPointF(gHands[gMySpectator.HandIndex].CenterScreen); //By default set viewport position to hand CenterScreen
 
   gMySpectator.Selected := LastSelectedObj;  // Change selected object to last one for this hand or Reset it to nil
+
   UpdateSelectedObject;
+  Replay_UpdatePlayerInterface;
 end;
 
 
@@ -1865,6 +1869,12 @@ begin
     UpdateSelectedObject;
   end;
 
+  Replay_UpdatePlayerInterface;
+end;
+
+
+procedure TKMGamePlayInterface.Replay_UpdatePlayerInterface;
+begin
   if Checkbox_ReplayFOW.Checked then
     gMySpectator.FOWIndex := gMySpectator.HandIndex
   else


### PR DESCRIPTION
When we were using hotkey to jump to player while spectating/watching replay, there was no Replay_ViewPlayer invokation, only Replay_JumpToPlayer, where there was no FOW and Overlay update. 
So we have to update it anyway, better separate that common code in one procedure - Replay_UpdatePlayerInterface.