### PR TITLE
mk_FPS can be sent to other players only, no need to send it to ourselfs

### DIFF
--- a/src/net/KM_Networking.pas
+++ b/src/net/KM_Networking.pas
@@ -2399,6 +2399,7 @@ begin
   begin
     PacketSend(NET_ADDRESS_OTHERS, mk_FPS, Integer(aFPS));
     GetMyNetPlayer.FPS := Cardinal(aFPS);
+    if Assigned(fOnPingInfo) then fOnPingInfo(Self);
   end;
 end;
 

--- a/src/net/KM_Networking.pas
+++ b/src/net/KM_Networking.pas
@@ -2396,7 +2396,10 @@ end;
 procedure TKMNetworking.FPSMeasurement(aFPS: Cardinal);
 begin
   if fNetGameState = lgs_Game then
-    PacketSend(NET_ADDRESS_ALL, mk_FPS, Integer(aFPS));
+  begin
+    PacketSend(NET_ADDRESS_OTHERS, mk_FPS, Integer(aFPS));
+    GetMyNetPlayer.FPS := Cardinal(aFPS);
+  end;
 end;
 
 


### PR DESCRIPTION
This packet is sent every second, we can save bit of network traffic then