### PR TITLE
Debug menu: Export images have transparent pixel

### DIFF
--- a/src/res/KM_ResSprites.pas
+++ b/src/res/KM_ResSprites.pas
@@ -448,10 +448,10 @@ begin
   end;
 
   //Mark pivot location with a dot
-  K := pngWidth + fRXData.Pivot[aIndex].x;
-  I := pngHeight + fRXData.Pivot[aIndex].y;
-  if InRange(I, 0, pngHeight-1) and InRange(K, 0, pngWidth-1) then
-    pngData[I*pngWidth + K] := $FF00FF;//}
+//  K := pngWidth + fRXData.Pivot[aIndex].x;
+//  I := pngHeight + fRXData.Pivot[aIndex].y;
+//  if InRange(I, 0, pngHeight-1) and InRange(K, 0, pngWidth-1) then
+//    pngData[I*pngWidth + K] := $FFFF00FF;
 
   SaveToPng(pngWidth, pngHeight, pngData, aFile);
 end;


### PR DESCRIPTION
This pixel should be a pivot pixel, but there was a bug - no alpha channel was set for pivot pixel, mean that pixel was transparent.
I believe there is no need for that pixel to be shown on image, as we want to get clean image, without anything extra on it. For pivot there is still txt file.

I have commented code, in case somebody will need to see this pivot on picture, but I do not want to add special parameter in menu for that
