### PR TITLE
Added beacons cooldown - to preven spam with beacons 

### DIFF
--- a/src/KM_Defaults.pas
+++ b/src/KM_Defaults.pas
@@ -156,6 +156,7 @@ const
 
   AUTOSAVE_COUNT       = 3;  //How many autosaves to backup
   CHAT_COOLDOWN        = 500; //Minimum time in milliseconds between chat messages
+  BEACON_COOLDOWN      = 800; //Minimum time in milliseconds between beacons
 
   DYNAMIC_HOTKEYS_NUM  = 20; // Number of dynamic hotkeys
 


### PR DESCRIPTION
Same as we have for chat messages.
I set beacon cooldown parameter to 800ms, as 500ms is too short - you can still spam a lot, when 1s is too long IMO. 