### PR TITLE
Bugfix: Ctrl+C/Ctrl+A in game chat memo - keyUp event was propagated further and binded hotkeys on C or A could trigger

### DIFF
--- a/src/KM_Controls.pas
+++ b/src/KM_Controls.pas
@@ -1157,6 +1157,7 @@ type
 
     function GetVisibleRows: Integer;
     function KeyDown(Key: Word; Shift: TShiftState): Boolean; override;
+    function KeyUp(Key: Word; Shift: TShiftState): Boolean; override;
     procedure MouseWheel(Sender: TObject; WheelDelta: Integer); override;
     procedure MouseDown(X,Y: Integer; Shift: TShiftState; Button: TMouseButton); override;
     procedure MouseMove(X,Y: Integer; Shift: TShiftState); override;
@@ -4279,8 +4280,7 @@ begin
   if (Shift = [ssCtrl]) and (Key <> VK_CONTROL) then
     case Key of
       Ord('A'): SetSelections(0, GetMaxCursorPos);
-      Ord('C'): if HasSelection then
-                  Clipboard.AsText := GetSelectedText;
+      Ord('C'),
       Ord('X'): if HasSelection then
                   Clipboard.AsText := GetSelectedText;
     end;
@@ -4323,6 +4323,12 @@ begin
       VK_HOME:  begin CursorPos := GetMinCursorPosInRow; ResetSelection; end;
       VK_END:   begin CursorPos := GetMaxCursorPosInRow; ResetSelection; end;
     end;
+end;
+
+
+function TKMMemo.KeyUp(Key: Word; Shift: TShiftState): Boolean;
+begin
+  Result := inherited KeyUp(Key, Shift) or KeyEventHandled(Key, Shift);
 end;
 
 


### PR DESCRIPTION
We have to handle Memo's KeyUp same as KeyDown - with KeyEventHandled function, which returns True on handled events