### PR TITLE
Bugfix: need to unlock mutex on MP game error or disconnect

### DIFF
--- a/src/KM_Game.pas
+++ b/src/KM_Game.pas
@@ -136,6 +136,7 @@ type
     property IsExiting: Boolean read fIsExiting;
     property IsPaused: Boolean read fIsPaused write fIsPaused;
     property MissionMode: TKMissionMode read fMissionMode write fMissionMode;
+    property GameLockedMutex: Boolean read fGameLockedMutex write fGameLockedMutex;
     function GetNewUID: Integer;
     function GetNormalGameSpeed: Single;
     procedure SetGameSpeed(aSpeed: Single; aToggle: Boolean);

--- a/src/KM_GameApp.pas
+++ b/src/KM_GameApp.pas
@@ -419,13 +419,21 @@ begin
   end;
 
   case aMsg of
-    gr_Win, gr_Defeat, gr_Cancel, gr_ReplayEnd:
-                    if (gGame.GameMode in [gmMulti, gmMultiSpectate, gmReplayMulti]) or MP_RESULTS_IN_SP then
+    gr_Win,
+    gr_Defeat,
+    gr_Cancel,
+    gr_ReplayEnd:   if (gGame.GameMode in [gmMulti, gmMultiSpectate, gmReplayMulti]) or MP_RESULTS_IN_SP then
                       fMainMenuInterface.ShowResultsMP(aMsg)
                     else
                       fMainMenuInterface.ShowResultsSP(aMsg);
-    gr_Error, gr_Disconnect:
-                    fMainMenuInterface.PageChange(gpError, aTextMsg);
+    gr_Error,
+    gr_Disconnect:  begin
+                      if gGame.IsMultiplayer then
+                        //After Error page User will go to the main menu, but Mutex will be still locked.
+                        //We will need to unlock it on gGame destroy, so mark it with GameLockedMutex
+                        gGame.GameLockedMutex := True;
+                      fMainMenuInterface.PageChange(gpError, aTextMsg);
+                    end;
     gr_Silent:      ;//Used when loading new savegame from gameplay UI
     gr_MapEdEnd:    fMainMenuInterface.PageChange(gpMapEditor);
   end;


### PR DESCRIPTION
Can happen on loading MP game error - error page will appear, from which user will get to the main menu page, but Mutex will be still locked and user will need to restart game to get to the multiplaer page.
