### PR TITLE
BugFix: DL maps could be changed and used to start the game, what will cause error on map load

### DIFF
--- a/src/KM_Maps.pas
+++ b/src/KM_Maps.pas
@@ -88,6 +88,7 @@ type
     function HasReadme: Boolean;
     function ViewReadme: Boolean;
     function GetLobbyColor: Cardinal;
+    function IsFilenameEndMatchHash: Boolean;
   end;
 
 
@@ -558,11 +559,19 @@ begin
 end;
 
 
+//Returns True if map filename ends with this map actual CRC hash.
+//Used to check if downloaded map was changed
+function TKMapInfo.IsFilenameEndMatchHash: Boolean;
+begin
+  Result := (Length(fFileName) > 9)
+    and (fFileName[Length(FileName)-8] = '_')
+    and (IntToHex(fCRC, 8) = RightStr(fFileName, 8));
+end;
+
+
 function TKMapInfo.FileNameWithoutHash: UnicodeString;
 begin
-  if (fMapFolder = mfDL) and (Length(FileName) > 9)
-  and (FileName[Length(FileName)-8] = '_')
-  and (IntToHex(fCRC, 8) = RightStr(FileName, 8)) then
+  if (MapFolder = mfDL) and IsFilenameEndMatchHash then
     Result := LeftStr(FileName, Length(FileName)-9)
   else
     Result := FileName;
@@ -1066,15 +1075,9 @@ var
 begin
   Map := TKMapInfo.Create(aPath, False, aFolder);
 
-  //Maps in the downloads folder must have correct hash appended for lobby logic to work
-  if (aFolder = mfDL) and (RightStr(aPath, 9) <> '_' + IntToHex(Map.CRC, 8)) then
-  begin
-    Map.Free;
-    Exit;
-  end;
-
   if SLOW_MAP_SCAN then
     Sleep(50);
+
   fOnMapAdd(Map);
   fOnMapAddDone(Self);
 end;

--- a/src/net/KM_Networking.pas
+++ b/src/net/KM_Networking.pas
@@ -601,7 +601,15 @@ begin
 
   if not fMapInfo.IsValid then
   begin
-    SelectNoMap('Invalid');
+    SelectNoMap('Map is invalid'); // Todo translate
+    PostLocalMessage('Selected map is invalid. Please select another map', csSystem); // Todo translate
+    Exit;
+  end;
+
+  if (aMapFolder = mfDL) and not fMapInfo.IsFilenameEndMatchHash then
+  begin
+    SelectNoMap('Downloaded map files have changed'); // Todo translate
+    PostLocalMessage('Selected DL map, which files have changed. Please move it out of downloads first', csSystem); // Todo translate
     Exit;
   end;
 
@@ -889,13 +897,15 @@ begin
                 AIUsableLocs := fMapInfo.AIUsableLocations;
                 //Check that map's hash hasn't changed
                 CheckMapInfo := TKMapInfo.Create(fMapInfo.FileName, True, fMapInfo.MapFolder);
-                if CheckMapInfo.CRC <> fMapInfo.CRC then
-                begin
-                  PostLocalMessage('Cannot start: Map files have changed. Please reselect the map', csSystem);
+                try
+                  if CheckMapInfo.CRC <> fMapInfo.CRC then
+                  begin
+                    PostLocalMessage(Format(gResTexts[TX_LOBBY_CANNOT_START], ['Map files have changed. Please reselect the map']), csSystem); // Todo translate
+                    Exit;
+                  end;
+                finally
                   CheckMapInfo.Free;
-                  Exit;
                 end;
-                CheckMapInfo.Free;
               end;
     ngk_Save: begin
                 HumanUsableLocs := fSaveInfo.Info.HumanUsableLocations;


### PR DESCRIPTION
Mostly its the script that could be changed. And because script can be changed only with external soft, than we have to consider this situation as normal for user.

In that case map CRC will be changed and did not match to map filename ending. We have to stop host from selecting this map, but let him see it in map editor list to make it possible 'Move out from downloads' or open and resave it. 
Otherwise user will be forced to make map files (script mainly) absolutely same, as it was at the moment of downloading, what is not easy to archive sometimes. Or manually rename and move all the map files to MapsMP folder, what is not good too.