### PR TITLE
Bugfix: lobby, select map, Map.OnChange could trigger twice

### DIFF
--- a/src/gui/pages_menu/KM_GUIMenuLobby.pas
+++ b/src/gui/pages_menu/KM_GUIMenuLobby.pas
@@ -1920,7 +1920,7 @@ end;
 function TKMMenuLobby.DropBoxMaps_CellClick(Sender: TObject; const X, Y: Integer): Boolean;
 var I: Integer;
 begin
-  Result := False;
+  Result := True; //we will handle mouse click here, and don't want to propagate it further
   if (Radio_LobbyMapType.ItemIndex < 4) and (X = 0) then
   begin
     I := DropCol_LobbyMaps.Item[Y].Tag;
@@ -1938,7 +1938,6 @@ begin
     finally
       fMapsMP.Unlock;
     end;
-    Result := True; //we handle mouse click here, and do want to propagate it further
   end;
 end;
 


### PR DESCRIPTION
OnCellClick has to handle click event in all cases, not only when clicked on 1st column