### PR TITLE
Add global BindTexture procedure, which do not apply bind for same texture

### DIFF
--- a/src/render/KM_RenderPool.pas
+++ b/src/render/KM_RenderPool.pas
@@ -1060,7 +1060,7 @@ begin
     // FOW is rendered over the top so no need to make sprites black anymore
     glColor4ub(255, 255, 255, 255);
 
-    glBindTexture(GL_TEXTURE_2D, Tex.Id);
+    TRender.BindTexture(Tex.Id);
     if DoHighlight then
       glColor3ub(HighlightColor AND $FF, HighlightColor SHR 8 AND $FF, HighlightColor SHR 16 AND $FF);
     glBegin(GL_QUADS);
@@ -1075,7 +1075,7 @@ begin
   with GFXData[aRX, aId] do
   begin
     glColor4ubv(@Col);
-    glBindTexture(GL_TEXTURE_2D, Alt.Id);
+    TRender.BindTexture(Alt.Id);
     glBegin(GL_QUADS);
       glTexCoord2f(Alt.u1, Alt.v2); glVertex2f(pX                     , pY                      );
       glTexCoord2f(Alt.u2, Alt.v2); glVertex2f(pX+pxWidth/CELL_SIZE_PX, pY                      );
@@ -1084,7 +1084,7 @@ begin
     glEnd;
   end;
 
-  glBindTexture(GL_TEXTURE_2D, 0);
+  TRender.BindTexture(0);
 end;
 
 
@@ -1120,14 +1120,14 @@ begin
     with GFXData[aRX,aId] do
     begin
       glColor3f(1, 1, 1);
-      glBindTexture(GL_TEXTURE_2D, Alt.Id);
+      TRender.BindTexture(Alt.Id);
       glBegin(GL_QUADS);
         glTexCoord2f(Alt.u1,Alt.v2); glVertex2f(pX                     ,pY         );
         glTexCoord2f(Alt.u2,Alt.v2); glVertex2f(pX+pxWidth/CELL_SIZE_PX,pY         );
         glTexCoord2f(Alt.u2,Alt.v1); glVertex2f(pX+pxWidth/CELL_SIZE_PX,pY-pxHeight/CELL_SIZE_PX);
         glTexCoord2f(Alt.u1,Alt.v1); glVertex2f(pX                     ,pY-pxHeight/CELL_SIZE_PX);
       glEnd;
-      glBindTexture(GL_TEXTURE_2D, 0);
+      TRender.BindTexture(0);
     end;
 
     // Stone progress
@@ -1139,14 +1139,14 @@ begin
         with GFXData[aRX,aId2] do
         begin
           glColor3f(1, 1, 1);
-          glBindTexture(GL_TEXTURE_2D, Alt.Id);
+          TRender.BindTexture(Alt.Id);
           glBegin(GL_QUADS);
             glTexCoord2f(Alt.u1,Alt.v2); glVertex2f(X2                     ,Y2         );
             glTexCoord2f(Alt.u2,Alt.v2); glVertex2f(X2+pxWidth/CELL_SIZE_PX,Y2         );
             glTexCoord2f(Alt.u2,Alt.v1); glVertex2f(X2+pxWidth/CELL_SIZE_PX,Y2-pxHeight/CELL_SIZE_PX);
             glTexCoord2f(Alt.u1,Alt.v1); glVertex2f(X2                     ,Y2-pxHeight/CELL_SIZE_PX);
           glEnd;
-          glBindTexture(GL_TEXTURE_2D, 0);
+          TRender.BindTexture(0);
         end;
     end;
 
@@ -1166,14 +1166,14 @@ begin
     // FOW is rendered over the top so no need to make sprites black anymore
     glColor4ub(255, 255, 255, 255);
 
-    glBindTexture(GL_TEXTURE_2D, Tex.Id);
+    TRender.BindTexture(Tex.Id);
     glBegin(GL_QUADS);
       glTexCoord2f(Tex.u1,Tex.v2); glVertex2f(pX                     ,pY         );
       glTexCoord2f(Tex.u2,Tex.v2); glVertex2f(pX+pxWidth/CELL_SIZE_PX,pY         );
       glTexCoord2f(Tex.u2,Tex.v1); glVertex2f(pX+pxWidth/CELL_SIZE_PX,pY-pxHeight/CELL_SIZE_PX);
       glTexCoord2f(Tex.u1,Tex.v1); glVertex2f(pX                     ,pY-pxHeight/CELL_SIZE_PX);
     glEnd;
-    glBindTexture(GL_TEXTURE_2D, 0);
+    TRender.BindTexture(0);
   end;
 
   glDisable(GL_STENCIL_TEST);

--- a/src/render/KM_RenderUI.pas
+++ b/src/render/KM_RenderUI.pas
@@ -37,7 +37,7 @@ type
 
 implementation
 uses
-  KM_Resource;
+  KM_Render, KM_Resource;
 
 
 //X axis uses planes 0,1 and Y axis uses planes 2,3, so that they don't interfere when both axis are
@@ -129,7 +129,7 @@ begin
 
       //Background
       glColor4f(1, 1, 1, 1);
-      glBindTexture(GL_TEXTURE_2D, GFXData[BackRX, BackID].Tex.ID);
+      TRender.BindTexture(GFXData[BackRX, BackID].Tex.ID);
       glBegin(GL_QUADS);
         glTexCoord2f(A.x,A.y); glVertex2f(0,0);
         glTexCoord2f(B.x,A.y); glVertex2f(aWidth,0);
@@ -138,7 +138,7 @@ begin
       glEnd;
 
       //Render beveled edges
-      glBindTexture(GL_TEXTURE_2D, 0);
+      TRender.BindTexture(0);
 
       c1 := 1 - Down;
       c2 := Down;
@@ -312,7 +312,7 @@ begin
       glTranslatef(aLeft + OffX, aTop + OffY, 0);
 
       //Base layer
-      glBindTexture(GL_TEXTURE_2D, Tex.ID);
+      TRender.BindTexture(Tex.ID);
       if aEnabled then glColor3f(1,1,1) else glColor3f(0.33,0.33,0.33);
       glBegin(GL_QUADS);
         glTexCoord2f(Tex.u1,Tex.v1); glVertex2f(0            , 0             );
@@ -324,7 +324,7 @@ begin
       //Color overlay for unit icons and scrolls
       if Alt.ID <> 0 then
       begin
-        glBindTexture(GL_TEXTURE_2D, Alt.ID);
+        TRender.BindTexture(Alt.ID);
         if aEnabled then
           glColor3ub(aColor AND $FF, aColor SHR 8 AND $FF, aColor SHR 16 AND $FF)
         else
@@ -340,7 +340,7 @@ begin
       //Highlight for active/focused/mouseOver images
       if aLightness <> 0 then
       begin
-        glBindTexture(GL_TEXTURE_2D, Tex.ID); //Replace AltID if it was used
+        TRender.BindTexture(Tex.ID); //Replace AltID if it was used
         if aLightness > 0 then
           glBlendFunc(GL_SRC_ALPHA, GL_ONE)
         else begin
@@ -359,7 +359,7 @@ begin
 
     glPopMatrix;
   end;
-  glBindTexture(GL_TEXTURE_2D, 0);
+  TRender.BindTexture(0);
 end;
 
 
@@ -570,7 +570,7 @@ begin
                 if PrevAtlas <> -1 then
                   glEnd; //End previous draw
                 PrevAtlas := Let.AtlasId;
-                glBindTexture(GL_TEXTURE_2D, FontData.TexID[Let.AtlasId]);
+                TRender.BindTexture(FontData.TexID[Let.AtlasId]);
                 glBegin(GL_QUADS);
               end;
 
@@ -585,7 +585,7 @@ begin
     if (I = Length(aText)) and (PrevAtlas <> -1) then
       glEnd;
   end;
-  glBindTexture(GL_TEXTURE_2D, 0);
+  TRender.BindTexture(0);
 
   if SHOW_TEXT_OUTLINES then
   begin
@@ -619,7 +619,7 @@ end;
 
 class procedure TKMRenderUI.WriteTexture(aLeft, aTop, aWidth, aHeight: SmallInt; aTexture: TTexture; aCol: TColor4);
 begin
-  glBindTexture(GL_TEXTURE_2D, aTexture.Tex);
+  TRender.BindTexture(aTexture.Tex);
 
   glColor4ubv(@aCol);
   glBegin(GL_QUADS);
@@ -629,7 +629,7 @@ begin
     glTexCoord2f(0, aTexture.V);          glVertex2f(aLeft, aTop+aHeight);
   glEnd;
 
-  glBindTexture(GL_TEXTURE_2D, 0);
+  TRender.BindTexture(0);
 end;
 
 


### PR DESCRIPTION
Same as for DoTiles optimisation, but in global scope:
added facade method TRender.BindTexture, which should be used every time we need to try bind a texture.