### PR TITLE
Set atlas size depending of video adapter. But not more then 2048

### DIFF
--- a/src/KM_BinPacking.pas
+++ b/src/KM_BinPacking.pas
@@ -29,9 +29,9 @@ type
     fImageID: Word; //Image that is using this bin (0 if unused)
     fRect: TBinRect; //Our dimensions
     fPad: Byte;
-    fNotFit: Word; //Minimum size that does not fit
+    fNotFit: Cardinal; //Minimum size that does not fit
   public
-    constructor Create(aRect: TBinRect; aPad: Byte; aImageID: Word);
+    constructor Create(aRect: TBinRect; aPad: Byte; aImageID: Word; aNotFit: Cardinal);
     destructor Destroy; override;
     function Insert(aItem: TIndexItem): TBin; //Return bin that has accepted the sprite, or nil of Bin is full
     function Width: Word;
@@ -105,14 +105,14 @@ end;
 
 
 { TBin }
-constructor TBin.Create(aRect: TBinRect; aPad: Byte; aImageID: Word);
+constructor TBin.Create(aRect: TBinRect; aPad: Byte; aImageID: Word; aNotFit: Cardinal);
 begin
   inherited Create;
 
   fRect := aRect; //Our dimensions
   fImageID := aImageID;
   fPad := aPad;
-  fNotFit := 65535;
+  fNotFit := aNotFit;
 end;
 
 
@@ -162,13 +162,13 @@ begin
     if (fRect.Width - aItem.X - fPad*2) * fRect.Height > (fRect.Height - aItem.Y - fPad*2) * fRect.Width then
     begin
       //Vertical split
-      fChild1 := TBin.Create(BinRect(fRect.X, fRect.Y, aItem.X + fPad*2, fRect.Height), fPad, 0);
-      fChild2 := TBin.Create(BinRect(fRect.X + aItem.X + fPad*2, fRect.Y, fRect.Width - aItem.X - fPad*2, fRect.Height), fPad, 0);
+      fChild1 := TBin.Create(BinRect(fRect.X, fRect.Y, aItem.X + fPad*2, fRect.Height), fPad, 0, fNotFit);
+      fChild2 := TBin.Create(BinRect(fRect.X + aItem.X + fPad*2, fRect.Y, fRect.Width - aItem.X - fPad*2, fRect.Height), fPad, 0, fNotFit);
     end else
     begin
       //Horizontal split
-      fChild1 := TBin.Create(BinRect(fRect.X, fRect.Y, fRect.Width, aItem.Y + fPad*2), fPad, 0);
-      fChild2 := TBin.Create(BinRect(fRect.X, fRect.Y + aItem.Y + fPad*2, fRect.Width, fRect.Height - aItem.Y - fPad*2), fPad, 0);
+      fChild1 := TBin.Create(BinRect(fRect.X, fRect.Y, fRect.Width, aItem.Y + fPad*2), fPad, 0, fNotFit);
+      fChild2 := TBin.Create(BinRect(fRect.X, fRect.Y + aItem.Y + fPad*2, fRect.Width, fRect.Height - aItem.Y - fPad*2), fPad, 0, fNotFit);
     end;
 
     //Now let the Child1 handle the Item
@@ -242,7 +242,7 @@ end;
 
 function TBinManager.CreateNew(aWidth: Word; aHeight: Word): TBin;
 begin
-  Result := TBin.Create(BinRect(0, 0, aWidth, aHeight), fPad, 0);
+  Result := TBin.Create(BinRect(0, 0, aWidth, aHeight), fPad, 0, fWidth*fHeight);
   fBins.Add(Result);
 end;
 

--- a/src/render/KM_Render.pas
+++ b/src/render/KM_Render.pas
@@ -55,11 +55,13 @@ type
 
 implementation
 uses
-  KM_Log;
+  KM_Log, KM_ResSprites;
 
 
 { TRender }
 constructor TRender.Create(aRenderControl: TKMRenderControl; ScreenX,ScreenY: Integer; aVSync: Boolean);
+var
+  MaxTextureSize: Integer;
 begin
   inherited Create;
 
@@ -69,6 +71,9 @@ begin
   if not fBlind then
   begin
     fRenderControl.CreateRenderContext;
+
+    glGetIntegerv(GL_MAX_TEXTURE_SIZE, @MaxTextureSize); //Get max supported texture size by video adapter
+    TKMResSprites.SetMaxAtlasSize(MaxTextureSize);       //Save it for texture processing
 
     glClearColor(0, 0, 0, 0); 	   //Background
     glClearStencil(0);

--- a/src/res/KM_ResSprites.pas
+++ b/src/res/KM_ResSprites.pas
@@ -133,7 +133,7 @@ const
 
 var
   LOG_EXTRA_GFX: Boolean = False;
-  AtlasSize: Integer;
+  MaxAtlasSize: Integer;
 
 
 { TKMSpritePack }
@@ -658,6 +658,7 @@ var
   I, K: Integer;
   SpriteSizes: TIndexSizeArray;
   SpriteInfo: TBinArray;
+  AtlasSize: Integer;
 begin
   BaseRAM := 0;
   ColorRAM := 0;
@@ -673,6 +674,14 @@ begin
     Inc(K);
   end;
   SetLength(SpriteSizes, K);
+
+  //For RX with only 1 texture we can set small size, as 512, it will be auto enlarged to POT(image size)
+  if K = 1 then
+    AtlasSize := 512
+  else if fRT = rxTiles then
+    AtlasSize := Min(MaxAtlasSize, 1024)    //For tiles 1024 is enought for now
+  else
+    AtlasSize := MaxAtlasSize;
 
   SetLength(SpriteInfo, 0);
   BinPack(SpriteSizes, AtlasSize, fPad, SpriteInfo);
@@ -825,7 +834,7 @@ end;
 
 class procedure TKMResSprites.SetMaxAtlasSize(aMaxSupportedTxSize: Integer);
 begin
-  AtlasSize := Min(aMaxSupportedTxSize, MAX_GAME_ATLAS_SIZE);
+  MaxAtlasSize := Min(aMaxSupportedTxSize, MAX_GAME_ATLAS_SIZE);
 end;
 
 

--- a/src/res/KM_ResSprites.pas
+++ b/src/res/KM_ResSprites.pas
@@ -99,6 +99,7 @@ type
     procedure LoadMenuResources;
     procedure LoadGameResources(aAlphaShadows: Boolean);
     procedure ClearTemp;
+    class procedure SetMaxAtlasSize(aMaxSupportedTxSize: Integer);
 
     property Sprites[aRT: TRXType]: TKMSpritePack read GetSprites; default;
 
@@ -127,9 +128,12 @@ implementation
 uses
   KromUtils, KM_Log, KM_BinPacking, KM_Utils;
 
+const
+  MAX_GAME_ATLAS_SIZE = 2048; //Max atlas size for KaM. No need for bigger atlases
 
 var
   LOG_EXTRA_GFX: Boolean = False;
+  AtlasSize: Integer;
 
 
 { TKMSpritePack }
@@ -650,8 +654,6 @@ type
                        ExportName[aMode] + IntToStr(aStartingIndex+I), TD);
     end;
   end;
-const
-  AtlasSize = 512;
 var
   I, K: Integer;
   SpriteSizes: TIndexSizeArray;
@@ -818,6 +820,12 @@ begin
     Exit;
 
   fSprites[aRT].OverloadFromFolder(ExeDir + 'Sprites' + PathDelim);
+end;
+
+
+class procedure TKMResSprites.SetMaxAtlasSize(aMaxSupportedTxSize: Integer);
+begin
+  AtlasSize := Min(aMaxSupportedTxSize, MAX_GAME_ATLAS_SIZE);
 end;
 
 


### PR DESCRIPTION
We were using atlas size = 512, which is quite small. Its worth considering to use bigger atlases.
We can get this info from video adapter to be sure what texture size is supported.

Also may be some atlas bin packing improvement can be done:
This is what we have now, when atlas size set to 2048x2048:

![img](https://puu.sh/xtfso/291cb5449f.png)

GUI_Base and GUIMain , as well as Custom_Base atlases are not packed well. May be its not important, but anyway...