### PR TITLE
Draw tiles with VBO, if possible

### DIFF
--- a/src/KM_BinPacking.pas
+++ b/src/KM_BinPacking.pas
@@ -29,9 +29,9 @@ type
     fImageID: Word; //Image that is using this bin (0 if unused)
     fRect: TBinRect; //Our dimensions
     fPad: Byte;
-    fNotFit: Word; //Minimum size that does not fit
+    fNotFit: Cardinal; //Minimum size that does not fit
   public
-    constructor Create(aRect: TBinRect; aPad: Byte; aImageID: Word);
+    constructor Create(aRect: TBinRect; aPad: Byte; aImageID: Word; aNotFit: Cardinal);
     destructor Destroy; override;
     function Insert(aItem: TIndexItem): TBin; //Return bin that has accepted the sprite, or nil of Bin is full
     function Width: Word;
@@ -105,14 +105,14 @@ end;
 
 
 { TBin }
-constructor TBin.Create(aRect: TBinRect; aPad: Byte; aImageID: Word);
+constructor TBin.Create(aRect: TBinRect; aPad: Byte; aImageID: Word; aNotFit: Cardinal);
 begin
   inherited Create;
 
   fRect := aRect; //Our dimensions
   fImageID := aImageID;
   fPad := aPad;
-  fNotFit := 65535;
+  fNotFit := aNotFit;
 end;
 
 
@@ -162,13 +162,13 @@ begin
     if (fRect.Width - aItem.X - fPad*2) * fRect.Height > (fRect.Height - aItem.Y - fPad*2) * fRect.Width then
     begin
       //Vertical split
-      fChild1 := TBin.Create(BinRect(fRect.X, fRect.Y, aItem.X + fPad*2, fRect.Height), fPad, 0);
-      fChild2 := TBin.Create(BinRect(fRect.X + aItem.X + fPad*2, fRect.Y, fRect.Width - aItem.X - fPad*2, fRect.Height), fPad, 0);
+      fChild1 := TBin.Create(BinRect(fRect.X, fRect.Y, aItem.X + fPad*2, fRect.Height), fPad, 0, fNotFit);
+      fChild2 := TBin.Create(BinRect(fRect.X + aItem.X + fPad*2, fRect.Y, fRect.Width - aItem.X - fPad*2, fRect.Height), fPad, 0, fNotFit);
     end else
     begin
       //Horizontal split
-      fChild1 := TBin.Create(BinRect(fRect.X, fRect.Y, fRect.Width, aItem.Y + fPad*2), fPad, 0);
-      fChild2 := TBin.Create(BinRect(fRect.X, fRect.Y + aItem.Y + fPad*2, fRect.Width, fRect.Height - aItem.Y - fPad*2), fPad, 0);
+      fChild1 := TBin.Create(BinRect(fRect.X, fRect.Y, fRect.Width, aItem.Y + fPad*2), fPad, 0, fNotFit);
+      fChild2 := TBin.Create(BinRect(fRect.X, fRect.Y + aItem.Y + fPad*2, fRect.Width, fRect.Height - aItem.Y - fPad*2), fPad, 0, fNotFit);
     end;
 
     //Now let the Child1 handle the Item
@@ -242,7 +242,7 @@ end;
 
 function TBinManager.CreateNew(aWidth: Word; aHeight: Word): TBin;
 begin
-  Result := TBin.Create(BinRect(0, 0, aWidth, aHeight), fPad, 0);
+  Result := TBin.Create(BinRect(0, 0, aWidth, aHeight), fPad, 0, fWidth*fHeight);
   fBins.Add(Result);
 end;
 

--- a/src/render/KM_Render.pas
+++ b/src/render/KM_Render.pas
@@ -55,11 +55,13 @@ type
 
 implementation
 uses
-  KM_Log;
+  KM_Log, KM_ResSprites;
 
 
 { TRender }
 constructor TRender.Create(aRenderControl: TKMRenderControl; ScreenX,ScreenY: Integer; aVSync: Boolean);
+var
+  MaxTextureSize: Integer;
 begin
   inherited Create;
 
@@ -69,6 +71,9 @@ begin
   if not fBlind then
   begin
     fRenderControl.CreateRenderContext;
+
+    glGetIntegerv(GL_MAX_TEXTURE_SIZE, @MaxTextureSize); //Get max supported texture size by video adapter
+    TKMResSprites.SetMaxAtlasSize(MaxTextureSize);       //Save it for texture processing
 
     glClearColor(0, 0, 0, 0); 	   //Background
     glClearStencil(0);

--- a/src/res/KM_ResSprites.pas
+++ b/src/res/KM_ResSprites.pas
@@ -133,7 +133,7 @@ const
 
 var
   LOG_EXTRA_GFX: Boolean = False;
-  AtlasSize: Integer;
+  MaxAtlasSize: Integer;
 
 
 { TKMSpritePack }
@@ -658,6 +658,7 @@ var
   I, K: Integer;
   SpriteSizes: TIndexSizeArray;
   SpriteInfo: TBinArray;
+  AtlasSize: Integer;
 begin
   BaseRAM := 0;
   ColorRAM := 0;
@@ -673,6 +674,14 @@ begin
     Inc(K);
   end;
   SetLength(SpriteSizes, K);
+
+  //For RX with only 1 texture we can set small size, as 512, it will be auto enlarged to POT(image size)
+  if K = 1 then
+    AtlasSize := 512
+  else if fRT = rxTiles then
+    AtlasSize := Min(MaxAtlasSize, 1024)    //For tiles 1024 is enought for now
+  else
+    AtlasSize := MaxAtlasSize;
 
   SetLength(SpriteInfo, 0);
   BinPack(SpriteSizes, AtlasSize, fPad, SpriteInfo);
@@ -825,7 +834,7 @@ end;
 
 class procedure TKMResSprites.SetMaxAtlasSize(aMaxSupportedTxSize: Integer);
 begin
-  AtlasSize := Min(aMaxSupportedTxSize, MAX_GAME_ATLAS_SIZE);
+  MaxAtlasSize := Min(aMaxSupportedTxSize, MAX_GAME_ATLAS_SIZE);
 end;
 
 

--- a/src/res/KM_ResSprites.pas
+++ b/src/res/KM_ResSprites.pas
@@ -99,6 +99,7 @@ type
     procedure LoadMenuResources;
     procedure LoadGameResources(aAlphaShadows: Boolean);
     procedure ClearTemp;
+    class procedure SetMaxAtlasSize(aMaxSupportedTxSize: Integer);
 
     property Sprites[aRT: TRXType]: TKMSpritePack read GetSprites; default;
 
@@ -127,9 +128,12 @@ implementation
 uses
   KromUtils, KM_Log, KM_BinPacking, KM_Utils;
 
+const
+  MAX_GAME_ATLAS_SIZE = 2048; //Max atlas size for KaM. No need for bigger atlases
 
 var
   LOG_EXTRA_GFX: Boolean = False;
+  AtlasSize: Integer;
 
 
 { TKMSpritePack }
@@ -650,8 +654,6 @@ type
                        ExportName[aMode] + IntToStr(aStartingIndex+I), TD);
     end;
   end;
-const
-  AtlasSize = 512;
 var
   I, K: Integer;
   SpriteSizes: TIndexSizeArray;
@@ -818,6 +820,12 @@ begin
     Exit;
 
   fSprites[aRT].OverloadFromFolder(ExeDir + 'Sprites' + PathDelim);
+end;
+
+
+class procedure TKMResSprites.SetMaxAtlasSize(aMaxSupportedTxSize: Integer);
+begin
+  AtlasSize := Min(aMaxSupportedTxSize, MAX_GAME_ATLAS_SIZE);
 end;
 
 


### PR DESCRIPTION
Use VBO when render tiles, if possible. 
It could be imposible, if only 512 textures are supported or if we will add many tiles in future, and then even 1024 will be not enought. Now we still have 131 free place for new tiles. 
Ehh...one day somebody will draw new tiles :)

So basically it will be always VBO, and it is good .

Can significantly improve performance - on my PC for some big map, from 20FPS (after previous improvements, before them it was 15 FPS) up to 26-29FPS. 

To use VBO for every tile I set 4 vertices, because each vertex can have different UV coordinates for surrounding textures. That is why we have to duplicate X,Y,Z and even Light,Shadow,FOW info.

Another option is to use separate arrays for tiles and for Light,Shadow,FOW. 
It will save some memory, but on the other hand it will require another indices array which probably will use same amount of memory. Also our application is not much video memory consuming, I believe, so its not a big deal IMHO.

This PR includes #415, so you can approve that one first and then this one, or just this one

There is a question about water animation. All water animation are also in 1 atlas now. But probably its not possible, because animation is from tile to tile, and I do not know any way to skip data from array, when there is no animation.
Am I right?