### PR TITLE
BugFix: serf could bring wood/stone to worker too early

### DIFF
--- a/src/units/KM_UnitTaskBuild.pas
+++ b/src/units/KM_UnitTaskBuild.pas
@@ -220,6 +220,7 @@ begin
          gTerrain.IncDigState(fLoc);
          SetActionLockedStay(11,ua_Work1,false);
        end;
+    //Warning! This step value is harcoded in KM_UnitTaskDelivery
     4: begin //This step is repeated until Serf brings us some stone
          SetActionLockedStay(30,ua_Work1);
          Thought := th_Stone;
@@ -360,6 +361,7 @@ begin
         SetActionLockedStay(30, ua_Work1);
         Thought := th_Wood;
       end;
+   //Warning! This step value is harcoded in KM_UnitTaskDelivery
    5: begin //This step is repeated until Serf brings us some wood
         SetActionLockedStay(30, ua_Work1);
         Thought := th_Wood;

--- a/src/units/KM_UnitTaskDelivery.pas
+++ b/src/units/KM_UnitTaskDelivery.pas
@@ -275,6 +275,7 @@ begin
           //Worker
           if (fToUnit.UnitType = ut_Worker) and (fToUnit.UnitTask <> nil) then
           begin
+            //ToDo: Replace phase numbers with enums to avoid hardcoded magic numbers
             // Check if worker is still digging
             if ((fToUnit.UnitTask is TTaskBuildWine) and (fToUnit.UnitTask.Phase < 5))
               or ((fToUnit.UnitTask is TTaskBuildRoad) and (fToUnit.UnitTask.Phase < 4)) then

--- a/src/units/KM_UnitTaskDelivery.pas
+++ b/src/units/KM_UnitTaskDelivery.pas
@@ -34,7 +34,7 @@ type
 
 implementation
 uses
-  KM_HandsCollection, KM_Units_Warrior, KM_Log, KM_HouseBarracks, KM_Hand;
+  KM_HandsCollection, KM_Units_Warrior, KM_Log, KM_HouseBarracks, KM_Hand, KM_UnitTaskBuild;
 
 
 { TTaskDeliver }
@@ -275,6 +275,14 @@ begin
           //Worker
           if (fToUnit.UnitType = ut_Worker) and (fToUnit.UnitTask <> nil) then
           begin
+            // Check if worker is still digging
+            if ((fToUnit.UnitTask is TTaskBuildWine) and (fToUnit.UnitTask.Phase < 5))
+              or ((fToUnit.UnitTask is TTaskBuildRoad) and (fToUnit.UnitTask.Phase < 4)) then
+            begin
+              SetActionLockedStay(5, ua_Walk); //wait until worker finish digging process
+              fPhase := 6;
+              Exit;
+            end;
             fToUnit.UnitTask.Phase := fToUnit.UnitTask.Phase + 1;
             fToUnit.SetActionLockedStay(0, ua_Work1); //Tell the worker to resume work by resetting his action (causes task to execute)
           end;


### PR DESCRIPTION
After some changes we order delivery earlier, than it was in r6720, so its possible, that serf will bring wood/stone too early, when worker did not finish his digging phase.
We have to ask serf to wait a bit, until worker is ready to use resource.

Bug:
https://puu.sh/xM07S/5c8df7954d.mp4

After fix:
https://puu.sh/xLZNG/83bfa6d1a0.mp4